### PR TITLE
Dqn atari

### DIFF
--- a/DQN/atari_wrappers.py
+++ b/DQN/atari_wrappers.py
@@ -1,0 +1,318 @@
+"""
+Copied from https://github.com/openai/baselines/blob/master/baselines/common/atari_wrappers.py
+"""
+import numpy as np
+import os
+os.environ.setdefault('PATH', '')
+from collections import deque
+import gym
+from gym import spaces
+import cv2
+cv2.ocl.setUseOpenCL(False)
+
+
+class TimeLimit(gym.Wrapper):
+    def __init__(self, env, max_episode_steps=None):
+        super(TimeLimit, self).__init__(env)
+        self._max_episode_steps = max_episode_steps
+        self._elapsed_steps = 0
+
+    def step(self, ac):
+        observation, reward, done, info = self.env.step(ac)
+        self._elapsed_steps += 1
+        if self._elapsed_steps >= self._max_episode_steps:
+            done = True
+            info['TimeLimit.truncated'] = True
+        return observation, reward, done, info
+
+    def reset(self, **kwargs):
+        self._elapsed_steps = 0
+        return self.env.reset(**kwargs)
+
+
+class NoopResetEnv(gym.Wrapper):
+    def __init__(self, env, noop_max=30):
+        """Sample initial states by taking random number of no-ops on reset.
+        No-op is assumed to be action 0.
+        """
+        gym.Wrapper.__init__(self, env)
+        self.noop_max = noop_max
+        self.override_num_noops = None
+        self.noop_action = 0
+        assert env.unwrapped.get_action_meanings()[0] == 'NOOP'
+
+    def reset(self, **kwargs):
+        """ Do no-op action for a number of steps in [1, noop_max]."""
+        self.env.reset(**kwargs)
+        if self.override_num_noops is not None:
+            noops = self.override_num_noops
+        else:
+            noops = self.unwrapped.np_random.randint(1, self.noop_max + 1) #pylint: disable=E1101
+        assert noops > 0
+        obs = None
+        for _ in range(noops):
+            obs, _, done, _ = self.env.step(self.noop_action)
+            if done:
+                obs = self.env.reset(**kwargs)
+        return obs
+
+    def step(self, ac):
+        return self.env.step(ac)
+
+
+class FireResetEnv(gym.Wrapper):
+    def __init__(self, env):
+        """Take action on reset for environments that are fixed until firing."""
+        gym.Wrapper.__init__(self, env)
+        assert env.unwrapped.get_action_meanings()[1] == 'FIRE'
+        assert len(env.unwrapped.get_action_meanings()) >= 3
+
+    def reset(self, **kwargs):
+        self.env.reset(**kwargs)
+        obs, _, done, _ = self.env.step(1)
+        if done:
+            self.env.reset(**kwargs)
+        obs, _, done, _ = self.env.step(2)
+        if done:
+            self.env.reset(**kwargs)
+        return obs
+
+    def step(self, ac):
+        return self.env.step(ac)
+
+
+class EpisodicLifeEnv(gym.Wrapper):
+    def __init__(self, env):
+        """Make end-of-life == end-of-episode, but only reset on true game over.
+        Done by DeepMind for the DQN and co. since it helps value estimation.
+        """
+        gym.Wrapper.__init__(self, env)
+        self.lives = 0
+        self.was_real_done  = True
+
+    def step(self, action):
+        obs, reward, done, info = self.env.step(action)
+        self.was_real_done = done
+        # check current lives, make loss of life terminal,
+        # then update lives to handle bonus lives
+        lives = self.env.unwrapped.ale.lives()
+        if lives < self.lives and lives > 0:
+            # for Qbert sometimes we stay in lives == 0 condition for a few frames
+            # so it's important to keep lives > 0, so that we only reset once
+            # the environment advertises done.
+            done = True
+        self.lives = lives
+        return obs, reward, done, info
+
+    def reset(self, **kwargs):
+        """Reset only when lives are exhausted.
+        This way all states are still reachable even though lives are episodic,
+        and the learner need not know about any of this behind-the-scenes.
+        """
+        if self.was_real_done:
+            obs = self.env.reset(**kwargs)
+        else:
+            # no-op step to advance from terminal/lost life state
+            obs, _, _, _ = self.env.step(0)
+        self.lives = self.env.unwrapped.ale.lives()
+        return obs
+
+
+class MaxAndSkipEnv(gym.Wrapper):
+    def __init__(self, env, skip=4):
+        """Return only every `skip`-th frame"""
+        gym.Wrapper.__init__(self, env)
+        # most recent raw observations (for max pooling across time steps)
+        self._obs_buffer = np.zeros((2,)+env.observation_space.shape, dtype=np.uint8)
+        self._skip       = skip
+
+    def step(self, action):
+        """Repeat action, sum reward, and max over last observations."""
+        total_reward = 0.0
+        done = None
+        for i in range(self._skip):
+            obs, reward, done, info = self.env.step(action)
+            if i == self._skip - 2: self._obs_buffer[0] = obs
+            if i == self._skip - 1: self._obs_buffer[1] = obs
+            total_reward += reward
+            if done:
+                break
+        # Note that the observation on the done=True frame
+        # doesn't matter
+        max_frame = self._obs_buffer.max(axis=0)
+
+        return max_frame, total_reward, done, info
+
+    def reset(self, **kwargs):
+        return self.env.reset(**kwargs)
+
+
+class ClipRewardEnv(gym.RewardWrapper):
+    def __init__(self, env):
+        gym.RewardWrapper.__init__(self, env)
+
+    def reward(self, reward):
+        """Bin reward to {+1, 0, -1} by its sign."""
+        return np.sign(reward)
+
+
+class WarpFrame(gym.ObservationWrapper):
+    def __init__(self, env, width=84, height=84, grayscale=True, dict_space_key=None):
+        """
+        Warp frames to 84x84 as done in the Nature paper and later work.
+
+        If the environment uses dictionary observations, `dict_space_key` can be specified which indicates which
+        observation should be warped.
+        """
+        super().__init__(env)
+        self._width = width
+        self._height = height
+        self._grayscale = grayscale
+        self._key = dict_space_key
+        if self._grayscale:
+            num_colors = 1
+        else:
+            num_colors = 3
+
+        new_space = gym.spaces.Box(
+            low=0,
+            high=255,
+            shape=(self._height, self._width, num_colors),
+            dtype=np.uint8,
+        )
+        if self._key is None:
+            original_space = self.observation_space
+            self.observation_space = new_space
+        else:
+            original_space = self.observation_space.spaces[self._key]
+            self.observation_space.spaces[self._key] = new_space
+        assert original_space.dtype == np.uint8 and len(original_space.shape) == 3
+
+    def observation(self, obs):
+        if self._key is None:
+            frame = obs
+        else:
+            frame = obs[self._key]
+
+        if self._grayscale:
+            frame = cv2.cvtColor(frame, cv2.COLOR_RGB2GRAY)
+        frame = cv2.resize(
+            frame, (self._width, self._height), interpolation=cv2.INTER_AREA
+        )
+        if self._grayscale:
+            frame = np.expand_dims(frame, -1)
+
+        if self._key is None:
+            obs = frame
+        else:
+            obs = obs.copy()
+            obs[self._key] = frame
+        return obs
+
+
+class FrameStack(gym.Wrapper):
+    def __init__(self, env, k):
+        """Stack k last frames.
+
+        Returns lazy array, which is much more memory efficient.
+
+        See Also
+        --------
+        baselines.common.atari_wrappers.LazyFrames
+        """
+        gym.Wrapper.__init__(self, env)
+        self.k = k
+        self.frames = deque([], maxlen=k)
+        shp = env.observation_space.shape
+        self.observation_space = spaces.Box(low=0, high=255, shape=(shp[:-1] + (shp[-1] * k,)), dtype=env.observation_space.dtype)
+
+    def reset(self):
+        ob = self.env.reset()
+        for _ in range(self.k):
+            self.frames.append(ob)
+        return self._get_ob()
+
+    def step(self, action):
+        ob, reward, done, info = self.env.step(action)
+        self.frames.append(ob)
+        return self._get_ob(), reward, done, info
+
+    def _get_ob(self):
+        assert len(self.frames) == self.k
+        return LazyFrames(list(self.frames))
+
+
+class ScaledFloatFrame(gym.ObservationWrapper):
+    def __init__(self, env):
+        gym.ObservationWrapper.__init__(self, env)
+        self.observation_space = gym.spaces.Box(low=0, high=1, shape=env.observation_space.shape, dtype=np.float32)
+
+    def observation(self, observation):
+        # careful! This undoes the memory optimization, use
+        # with smaller replay buffers only.
+        return np.array(observation).astype(np.float32) / 255.0
+
+
+class LazyFrames(object):
+    def __init__(self, frames):
+        """This object ensures that common frames between the observations are only stored once.
+        It exists purely to optimize memory usage which can be huge for DQN's 1M frames replay
+        buffers.
+
+        This object should only be converted to numpy array before being passed to the model.
+
+        You'd not believe how complex the previous solution was."""
+        self._frames = frames
+        self._out = None
+
+    def _force(self):
+        if self._out is None:
+            self._out = np.concatenate(self._frames, axis=-1)
+            self._frames = None
+        return self._out
+
+    def __array__(self, dtype=None):
+        out = self._force()
+        if dtype is not None:
+            out = out.astype(dtype)
+        return out
+
+    def __len__(self):
+        return len(self._force())
+
+    def __getitem__(self, i):
+        return self._force()[i]
+
+    def count(self):
+        frames = self._force()
+        return frames.shape[frames.ndim - 1]
+
+    def frame(self, i):
+        return self._force()[..., i]
+
+
+def make_atari(env_id, max_episode_steps=None):
+    env = gym.make(env_id)
+    assert 'NoFrameskip' in env.spec.id
+    env = NoopResetEnv(env, noop_max=30)
+    env = MaxAndSkipEnv(env, skip=4)
+    if max_episode_steps is not None:
+        env = TimeLimit(env, max_episode_steps=max_episode_steps)
+    return env
+
+
+def wrap_deepmind(env, episode_life=True, clip_rewards=True, frame_stack=False, scale=False):
+    """Configure environment for DeepMind-style Atari.
+    """
+    if episode_life:
+        env = EpisodicLifeEnv(env)
+    if 'FIRE' in env.unwrapped.get_action_meanings():
+        env = FireResetEnv(env)
+    env = WarpFrame(env)
+    if scale:
+        env = ScaledFloatFrame(env)
+    if clip_rewards:
+        env = ClipRewardEnv(env)
+    if frame_stack:
+        env = FrameStack(env, 4)
+    return env

--- a/DQN/environment.yml
+++ b/DQN/environment.yml
@@ -2,6 +2,7 @@ name: dqn
 channels:
 dependencies:
   - python=3.6
+  - jupyter
   - pip
   - pip:
     - -e git+https://github.com/openai/spinningup.git@master#egg=spinup

--- a/DQN/gym_environments.ipynb
+++ b/DQN/gym_environments.ipynb
@@ -15,7 +15,12 @@
    "source": [
     "import gym\n",
     "import numpy as np\n",
-    "from matplotlib import pyplot as plt"
+    "import sys\n",
+    "if \"./\" not in sys.path:\n",
+    "    sys.path.append(\"./\")\n",
+    "\n",
+    "from matplotlib import pyplot as plt\n",
+    "%matplotlib inline"
    ]
   },
   {
@@ -27,16 +32,25 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": 2,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "/Users/yeh/miniconda3/envs/dqn/lib/python3.6/site-packages/gym/logger.py:30: UserWarning: \u001b[33mWARN: Box bound precision lowered by casting to float32\u001b[0m\n",
+      "  warnings.warn(colorize('%s: %s'%('WARN', msg % args), 'yellow'))\n"
+     ]
+    }
+   ],
    "source": [
     "env = gym.envs.make(\"CartPole-v1\")"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 13,
+   "execution_count": 3,
    "metadata": {},
    "outputs": [
     {
@@ -65,7 +79,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 33,
+   "execution_count": 4,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -74,7 +88,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 34,
+   "execution_count": 5,
    "metadata": {},
    "outputs": [
     {
@@ -91,22 +105,22 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 35,
+   "execution_count": 6,
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "<matplotlib.image.AxesImage at 0x121ab55c0>"
+       "<matplotlib.image.AxesImage at 0x12f239b00>"
       ]
      },
-     "execution_count": 35,
+     "execution_count": 6,
      "metadata": {},
      "output_type": "execute_result"
     },
     {
      "data": {
-      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAW4AAAD8CAYAAABXe05zAAAABHNCSVQICAgIfAhkiAAAAAlwSFlzAAALEgAACxIB0t1+/AAAADh0RVh0U29mdHdhcmUAbWF0cGxvdGxpYiB2ZXJzaW9uMy4xLjMsIGh0dHA6Ly9tYXRwbG90bGliLm9yZy+AADFEAAARgklEQVR4nO3dcaydd33f8fenTgisoCYhN5FrO3XaehrpNBx2F1xlf6SBtiGqZirBlGwqFopkJgUJJLQt6aQWpEVqpZVUaFuEq6SYihGyAooVZaOeCar4g4QbMMbGpDFgkVtb8WUkAYSWLuHbP87vwqlz7Ht87z2593fP+yUdnef5Pr/nnO9Pufn48e8+xydVhSSpHz+31g1Iki6MwS1JnTG4JakzBrckdcbglqTOGNyS1JmJBXeSm5M8meREkjsn9T6SNG0yifu4k2wC/gb4TWAe+DJwW1V9Y9XfTJKmzKSuuK8HTlTVt6vq74AHgN0Tei9JmioXTeh1twBPD+3PA28+1+Arrriitm/fPqFWJKk/J0+e5Hvf+15GHZtUcI96s3+wJpNkL7AX4Oqrr2Zubm5CrUhSf2ZnZ895bFJLJfPAtqH9rcCp4QFVta+qZqtqdmZmZkJtSNLGM6ng/jKwI8k1SV4F3AocmNB7SdJUmchSSVW9mOS9wOeATcD9VXVsEu8lSdNmUmvcVNUjwCOTen1JmlZ+clKSOmNwS1JnDG5J6ozBLUmdMbglqTMGtyR1xuCWpM4Y3JLUGYNbkjpjcEtSZwxuSeqMwS1JnTG4JakzBrckdcbglqTOGNyS1BmDW5I6Y3BLUmdW9NVlSU4CPwReAl6sqtkklwOfArYDJ4F/XVXPrqxNSdKi1bji/o2q2llVs23/TuBQVe0ADrV9SdIqmcRSyW5gf9veD7x9Au8hSVNrpcFdwF8leSLJ3la7qqpOA7TnK1f4HpKkISta4wZuqKpTSa4EDib55rgntqDfC3D11VevsA1Jmh4ruuKuqlPt+QzwWeB64JkkmwHa85lznLuvqmaranZmZmYlbUjSVFl2cCf5+SSvW9wGfgs4ChwA9rRhe4CHVtqkJOlnVrJUchXw2SSLr/M/qup/J/ky8GCS24HvAu9ceZuSpEXLDu6q+jbwxhH1/wu8ZSVNSZLOzU9OSlJnDG5J6ozBLUmdMbglqTMGtyR1xuCWpM4Y3JLUGYNbkjpjcEtSZwxuSeqMwS1JnTG4JakzBrckdcbglqTOGNyS1BmDW5I6Y3BLUmcMbknqjMEtSZ1ZMriT3J/kTJKjQ7XLkxxM8lR7vqzVk+QjSU4kOZLkTZNsXpKm0ThX3B8Dbj6rdidwqKp2AIfaPsDbgB3tsRe4d3XalCQtWjK4q+qvge+fVd4N7G/b+4G3D9U/XgNfAi5Nsnm1mpUkLX+N+6qqOg3Qnq9s9S3A00Pj5lvtZZLsTTKXZG5hYWGZbUjS9FntX05mRK1GDayqfVU1W1WzMzMzq9yGJG1cyw3uZxaXQNrzmVafB7YNjdsKnFp+e5Kksy03uA8Ae9r2HuChofq72t0lu4DnF5dUJEmr46KlBiT5JHAjcEWSeeAPgT8CHkxyO/Bd4J1t+CPALcAJ4MfAuyfQsyRNtSWDu6puO8eht4wYW8AdK21KknRufnJSkjpjcEtSZwxuSeqMwS1JnTG4JakzBrckdcbglqTOGNyS1BmDW5I6Y3BLUmcMbknqjMEtSZ0xuCWpMwa3JHXG4JakzhjcktQZg1uSOmNwS1JnlgzuJPcnOZPk6FDtg0n+Nsnh9rhl6NhdSU4keTLJb0+qcUmaVuNccX8MuHlE/Z6q2tkejwAkuRa4Ffi1ds5/T7JptZqVJI0R3FX118D3x3y93cADVfVCVX2Hwbe9X7+C/iRJZ1nJGvd7kxxpSymXtdoW4OmhMfOt9jJJ9iaZSzK3sLCwgjYkabosN7jvBX4F2AmcBv6k1TNibI16garaV1WzVTU7MzOzzDYkafosK7ir6pmqeqmqfgL8GT9bDpkHtg0N3QqcWlmLkqRhywruJJuHdn8XWLzj5ABwa5JLklwD7AAeX1mLkqRhFy01IMkngRuBK5LMA38I3JhkJ4NlkJPAewCq6liSB4FvAC8Cd1TVS5NpXZKm05LBXVW3jSjfd57xdwN3r6QpSdK5+clJSeqMwS1JnTG4JakzBrckdcbglqTOGNyS1JklbweUptUT+94zsv7P9370Fe5E+oe84pYugKGt9cDglqTOGNyS1BmDW5I6Y3BLUmcMbknqjMEtSZ0xuCWpMwa3JHXG4JakzhjcktSZJYM7ybYkjyY5nuRYkve1+uVJDiZ5qj1f1upJ8pEkJ5IcSfKmSU9CWm3n+ndKpPVgnCvuF4EPVNUbgF3AHUmuBe4EDlXVDuBQ2wd4G4Nvd98B7AXuXfWuJWmKLRncVXW6qr7Stn8IHAe2ALuB/W3YfuDtbXs38PEa+BJwaZLNq965JE2pC1rjTrIduA54DLiqqk7DINyBK9uwLcDTQ6fNt9rZr7U3yVySuYWFhQvvXJKm1NjBneS1wKeB91fVD843dEStXlao2ldVs1U1OzMzM24bkjT1xgruJBczCO1PVNVnWvmZxSWQ9nym1eeBbUOnbwVOrU67kqRx7ioJcB9wvKo+PHToALCnbe8BHhqqv6vdXbILeH5xSUWStHLjfHXZDcDvAV9PcrjVfh/4I+DBJLcD3wXe2Y49AtwCnAB+DLx7VTuWpCm3ZHBX1RcZvW4N8JYR4wu4Y4V9SZLOwU9OSlJnDG5J6ozBLY3Jb3jXemFwS1JnDG5J6ozBLUmdMbglqTMGtyR1xuCWpM4Y3JLUGYNbkjpjcEtSZwxuSeqMwS2dZdQ3vPtxd60nBrckdcbglqTOGNyS1BmDW5I6M86XBW9L8miS40mOJXlfq38wyd8mOdwetwydc1eSE0meTPLbk5yAJE2bcb4s+EXgA1X1lSSvA55IcrAdu6eq/svw4CTXArcCvwb8IvB/kvzjqnppNRuXpGm15BV3VZ2uqq+07R8Cx4Et5zllN/BAVb1QVd9h8G3v169Gs5KkC1zjTrIduA54rJXem+RIkvuTXNZqW4Cnh06b5/xBL0m6AGMHd5LXAp8G3l9VPwDuBX4F2AmcBv5kceiI02vE6+1NMpdkbmFh4YIbl6RpNVZwJ7mYQWh/oqo+A1BVz1TVS1X1E+DP+NlyyDywbej0rcCps1+zqvZV1WxVzc7MzKxkDtKqGfWpSWm9GeeukgD3Acer6sND9c1Dw34XONq2DwC3JrkkyTXADuDx1WtZkqbbOHeV3AD8HvD1JIdb7feB25LsZLAMchJ4D0BVHUvyIPANBnek3OEdJZK0epYM7qr6IqPXrR85zzl3A3evoC9J0jn4yUlJ6ozBLUmdMbglqTMGtyR1xuCWpM4Y3JLUGYNbkjpjcEtSZwxuaQl+w7vWG4NbkjpjcEtSZwxuSeqMwS1JnTG4teElGfsxifOl1WZwS1JnxvkiBWmqPHx670+3f2fzvjXsRBrNK25pyHBoj9qX1gODW5I6M86XBb86yeNJvpbkWJIPtfo1SR5L8lSSTyV5Vatf0vZPtOPbJzsFaXXMfdSra/VhnCvuF4CbquqNwE7g5iS7gD8G7qmqHcCzwO1t/O3As1X1q8A9bZzUhbPXtF3j1no0zpcFF/CjtntxexRwE/BvWn0/8EHgXmB32wb4S+C/Jkl7HWndmn3PYkj/LKw/uCadSOc31hp3kk1JDgNngIPAt4DnqurFNmQe2NK2twBPA7TjzwOvX82mJWmajRXcVfVSVe0EtgLXA28YNaw9j/oUwsuutpPsTTKXZG5hYWHcfiVp6l3QXSVV9RzwBWAXcGmSxaWWrcCptj0PbANox38B+P6I19pXVbNVNTszM7O87iVpCo1zV8lMkkvb9muAtwLHgUeBd7Rhe4CH2vaBtk87/nnXtyVp9YzzycnNwP4kmxgE/YNV9XCSbwAPJPnPwFeB+9r4+4C/SHKCwZX2rRPoW5Km1jh3lRwBrhtR/zaD9e6z6/8PeOeqdCdJehk/OSlJnTG4JakzBrckdcZ/1lUbnjc1aaPxiluSOmNwS1JnDG5J6ozBLUmdMbglqTMGtyR1xuCWpM4Y3JLUGYNbkjpjcEtSZwxuSeqMwS1JnTG4JakzBrckdWacLwt+dZLHk3wtybEkH2r1jyX5TpLD7bGz1ZPkI0lOJDmS5E2TnoQkTZNx/j3uF4CbqupHSS4Gvpjkf7Vj/76q/vKs8W8DdrTHm4F727MkaRUsecVdAz9quxe3x/n+ZfrdwMfbeV8CLk2yeeWtSpJgzDXuJJuSHAbOAAer6rF26O62HHJPkktabQvw9NDp860mSVoFYwV3Vb1UVTuBrcD1Sf4pcBfwT4B/AVwO/Mc2PKNe4uxCkr1J5pLMLSwsLKt5SZpGF3RXSVU9B3wBuLmqTrflkBeAPweub8PmgW1Dp20FTo14rX1VNVtVszMzM8tqXpKm0Th3lcwkubRtvwZ4K/DNxXXrJAHeDhxtpxwA3tXuLtkFPF9VpyfSvSRNoXHuKtkM7E+yiUHQP1hVDyf5fJIZBksjh4F/18Y/AtwCnAB+DLx79duWpOm1ZHBX1RHguhH1m84xvoA7Vt6aJGkUPzkpSZ0xuCWpMwa3JHXG4JakzhjcktQZg1uSOmNwS1JnDG5J6ozBLUmdMbglqTMGtyR1xuCWpM4Y3JLUGYNbkjpjcEtSZwxuSeqMwS1JnTG4JakzBrckdcbglqTOGNyS1BmDW5I6k6pa6x5I8kPgybXuY0KuAL631k1MwEadF2zcuTmvvvxSVc2MOnDRK93JOTxZVbNr3cQkJJnbiHPbqPOCjTs357VxuFQiSZ0xuCWpM+sluPetdQMTtFHntlHnBRt3bs5rg1gXv5yUJI1vvVxxS5LGtObBneTmJE8mOZHkzrXu50IluT/JmSRHh2qXJzmY5Kn2fFmrJ8lH2lyPJHnT2nV+fkm2JXk0yfEkx5K8r9W7nluSVyd5PMnX2rw+1OrXJHmszetTSV7V6pe0/RPt+Pa17H8pSTYl+WqSh9v+RpnXySRfT3I4yVyrdf2zuBJrGtxJNgH/DXgbcC1wW5Jr17KnZfgYcPNZtTuBQ1W1AzjU9mEwzx3tsRe49xXqcTleBD5QVW8AdgF3tP82vc/tBeCmqnojsBO4Ocku4I+Be9q8ngVub+NvB56tql8F7mnj1rP3AceH9jfKvAB+o6p2Dt361/vP4vJV1Zo9gF8HPje0fxdw11r2tMx5bAeODu0/CWxu25sZ3KcO8FHgtlHj1vsDeAj4zY00N+AfAV8B3szgAxwXtfpPfy6BzwG/3rYvauOy1r2fYz5bGQTYTcDDQDbCvFqPJ4ErzqptmJ/FC32s9VLJFuDpof35VuvdVVV1GqA9X9nqXc63/TX6OuAxNsDc2nLCYeAMcBD4FvBcVb3Yhgz3/tN5tePPA69/ZTse258C/wH4Sdt/PRtjXgAF/FWSJ5LsbbXufxaXa60/OZkRtY18m0t3803yWuDTwPur6gfJqCkMho6orcu5VdVLwM4klwKfBd4walh77mJeSX4HOFNVTyS5cbE8YmhX8xpyQ1WdSnIlcDDJN88ztre5XbC1vuKeB7YN7W8FTq1RL6vpmSSbAdrzmVbvar5JLmYQ2p+oqs+08oaYG0BVPQd8gcEa/qVJFi9khnv/6bza8V8Avv/KdjqWG4B/leQk8ACD5ZI/pf95AVBVp9rzGQZ/2F7PBvpZvFBrHdxfBna033y/CrgVOLDGPa2GA8Cetr2HwfrwYv1d7bfeu4DnF/+qt95kcGl9H3C8qj48dKjruSWZaVfaJHkN8FYGv8x7FHhHG3b2vBbn+w7g89UWTteTqrqrqrZW1XYG/x99vqr+LZ3PCyDJzyd53eI28FvAUTr/WVyRtV5kB24B/obBOuN/Wut+ltH/J4HTwP9n8Cf97QzWCg8BT7Xny9vYMLiL5lvA14HZte7/PPP6lwz+enkEONwet/Q+N+CfAV9t8zoK/EGr/zLwOHAC+J/AJa3+6rZ/oh3/5bWewxhzvBF4eKPMq83ha+1xbDEnev9ZXMnDT05KUmfWeqlEknSBDG5J6ozBLUmdMbglqTMGtyR1xuCWpM4Y3JLUGYNbkjrz96729c8lYGmAAAAAAElFTkSuQmCC\n",
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAW4AAAD8CAYAAABXe05zAAAABHNCSVQICAgIfAhkiAAAAAlwSFlzAAALEgAACxIB0t1+/AAAADh0RVh0U29mdHdhcmUAbWF0cGxvdGxpYiB2ZXJzaW9uMy4xLjEsIGh0dHA6Ly9tYXRwbG90bGliLm9yZy8QZhcZAAAR3UlEQVR4nO3dUYxd113v8e+PuEkhQGyHwTK2RVLVahQhNUlHwVF5KDUpSajqPJQqESJWsDRIBGgBCdx7HyokHloJERrpKopvU3BRlTaEQqwQtQQ3FeKhaSc0pGnS4GlIsC0nnobUhVbcS+DPw1nTnjh25hz7TMZrzvcjHZ21/3udOWtpj3/es2af2akqJEn9+IHVHoAkaTwGtyR1xuCWpM4Y3JLUGYNbkjpjcEtSZ1YkuJNcl+TpJAtJ9q7Ee0jStMqkr+NOch7wT8C1wBHgy8DNVfXkRN9IkqbUSpxxXw0sVNUzVfX/gU8Bu1bgfSRpKq1bga+5BTg8tH0E+OmTOyWZA+YALrzwwrdddtllKzAUSerTs88+yze/+c2cat9KBPdIqmofsA9gdna25ufnV2soknTOmZ2dPe2+lVgqOQpsG9re2mqSpAlYieD+MrA9yaVJzgduAg6swPtI0lSa+FJJVb2c5NeBzwHnAR+vqq9N+n0kaVqtyBp3VT0IPLgSX1uSpp2fnJSkzhjcktQZg1uSOmNwS1JnDG5J6ozBLUmdMbglqTMGtyR1xuCWpM4Y3JLUGYNbkjpjcEtSZwxuSeqMwS1JnTG4JakzBrckdcbglqTOGNyS1JllgzvJx5McT/LEUG1jkoeSHGrPG1o9Se5IspDk8SRXreTgJWkajXLG/afAdSfV9gIHq2o7cLBtA1wPbG+POeDOyQxTkrRk2eCuqr8D/vWk8i5gf2vvB24cqn+iBr4IrE+yeVKDlSSd+Rr3pqo61trPA5taewtweKjfkVaTJE3IWf9ysqoKqHFfl2QuyXyS+cXFxbMdhiRNjTMN7heWlkDa8/FWPwpsG+q3tdVepar2VdVsVc3OzMyc4TAkafqcaXAfAHa39m7g/qH6Le3qkh3AiaElFUnSBKxbrkOSe4B3AD+W5AjwIeDDwL1J9gDPAe9r3R8EbgAWgO8Ct67AmCVpqi0b3FV182l27TxF3wJuO9tBSZJOz09OSlJnDG5J6ozBLUmdMbglqTMGtyR1xuCWpM4Y3JLUGYNbkjpjcEtSZwxuSeqMwS1JnTG4JakzBrckdcbglqTOGNyS1BmDW5I6Y3BLUmcMbknqjMEtSZ1ZNriTbEvycJInk3wtyftbfWOSh5Icas8bWj1J7kiykOTxJFet9CQkaZqMcsb9MvA7VXU5sAO4LcnlwF7gYFVtBw62bYDrge3tMQfcOfFRS9IUWza4q+pYVf1Da/8b8BSwBdgF7G/d9gM3tvYu4BM18EVgfZLNEx+5JE2psda4k1wCXAk8AmyqqmNt1/PAptbeAhweetmRVjv5a80lmU8yv7i4OOawJWl6jRzcSX4Y+AvgA1X17eF9VVVAjfPGVbWvqmaranZmZmacl0rSVBspuJO8gUFof7KqPtPKLywtgbTn461+FNg29PKtrSZJmoBRrioJcDfwVFX90dCuA8Du1t4N3D9Uv6VdXbIDODG0pCJJOkvrRujzduCXga8meazV/hfwYeDeJHuA54D3tX0PAjcAC8B3gVsnOmJJmnLLBndV/T2Q0+zeeYr+Bdx2luOSJJ2Gn5yUpM4Y3JLUGYNbkjpjcEtSZwxuSeqMwS1JnTG4JakzBrckdcbglqTOGNyS1BmDW5I6Y3BLUmcMbknqjMEtSZ0xuCWpMwa3JHXG4JakzhjcktSZUW4W/MYkX0ryj0m+luT3W/3SJI8kWUjy6STnt/oFbXuh7b9kZacgSdNllDPu/we8s6reClwBXNfu3v4R4PaqejPwErCn9d8DvNTqt7d+kqQJWTa4a+Df2+Yb2qOAdwL3tfp+4MbW3tW2aft3JjndzYYlSWMaaY07yXlJHgOOAw8B3wC+VVUvty5HgC2tvQU4DND2nwAuPsXXnEsyn2R+cXHx7GYhSVNkpOCuqv+qqiuArcDVwGVn+8ZVta+qZqtqdmZm5my/nCRNjbGuKqmqbwEPA9cA65Osa7u2Akdb+yiwDaDtvwh4cSKjlSSNdFXJTJL1rf2DwLXAUwwC/L2t227g/tY+0LZp+z9fVTXJQUvSNFu3fBc2A/uTnMcg6O+tqgeSPAl8KskfAF8B7m797wb+LMkC8K/ATSswbkmaWssGd1U9Dlx5ivozDNa7T67/B/CLExmdJOlV/OSkJHXG4JakzhjcktQZg1uSOmNwS1JnDG5J6swo13FLa96j+371VbW3zd21CiORlucZtyR1xuCWpM4Y3JLUGYNbkjpjcEtSZwxuSeqMwS2dxqkuEZTOBQa3JHXG4JakzhjcktQZg1uSOjNycCc5L8lXkjzQti9N8kiShSSfTnJ+q1/Qthfa/ktWZuiSNJ3GOeN+P4O7uy/5CHB7Vb0ZeAnY0+p7gJda/fbWTzqn+Qel1JORgjvJVuAXgI+17QDvBO5rXfYDN7b2rrZN27+z9ZckTcCoZ9x/DPwu8N9t+2LgW1X1cts+Amxp7S3AYYC2/0Tr/wpJ5pLMJ5lfXFw8w+FL0vRZNriTvBs4XlWPTvKNq2pfVc1W1ezMzMwkv7QkrWmj3Ejh7cB7ktwAvBH4UeCjwPok69pZ9VbgaOt/FNgGHEmyDrgIeHHiI5ekKbXsGXdVfbCqtlbVJcBNwOer6peAh4H3tm67gftb+0Dbpu3/fFXVREctSVPsbK7j/j3gt5MsMFjDvrvV7wYubvXfBvae3RAlScPGuudkVX0B+EJrPwNcfYo+/wH84gTGJkk6BT85KUmdMbglqTMGtyR1xuCWXoM3U9C5yOCWpM4Y3JLUGYNbkjpjcEtSZwxuSeqMwS1JnTG4JakzBrckdcbglqTOGNyS1BmDW2q807t6YXBLUmcMbknqjMEtSZ0ZKbiTPJvkq0keSzLfahuTPJTkUHve0OpJckeShSSPJ7lqJScgSdNmnDPun62qK6pqtm3vBQ5W1XbgIN+/KfD1wPb2mAPunNRgJUlnt1SyC9jf2vuBG4fqn6iBLwLrk2w+i/eRJA0ZNbgL+JskjyaZa7VNVXWstZ8HNrX2FuDw0GuPtNorJJlLMp9kfnFx8QyGLknTad2I/X6mqo4m+XHgoSRfH95ZVZWkxnnjqtoH7AOYnZ0d67WSNM1GOuOuqqPt+Tjwl8DVwAtLSyDt+XjrfhTYNvTyra0mSZqAZYM7yYVJfmSpDbwLeAI4AOxu3XYD97f2AeCWdnXJDuDE0JKKJOksjXLGvQn4+yT/CHwJ+Ouq+izwYeDaJIeAn2vbAA8CzwALwP8Ffm3io5ZeR97pXeeaZde4q+oZ4K2nqL8I7DxFvYDbJjI6SdKr+MlJSeqMwS1JnTG4JakzBrckdcbglqTOGNyS1BmDW5I6Y3BLUmcMbknqjMEtDfFO7+qBwS1JnTG4JakzBrckdcbg1lRIMvJjJV4vTZLBLUmdGfWek9JUeeDY3EmVfasyDulUPOOWTvLq0JbOLQa3JHVmpOBOsj7JfUm+nuSpJNck2ZjkoSSH2vOG1jdJ7kiykOTxJFet7BQkabqMesb9UeCzVXUZg/tPPgXsBQ5W1XbgYNsGuB7Y3h5zwJ0THbG0wt69+dXr2fN3uXyic0cG9/Z9jQ7JRcBjwJtqqHOSp4F3VNWxJJuBL1TVW5Lc1dr3nNzvdO8xOztb8/PzE5iOdGqv52V6y/2bkkYxOzvL/Pz8Kb9xRznjvhRYBP4kyVeSfCzJhcCmoTB+HtjU2luAw0OvP9JqkqQJGCW41wFXAXdW1ZXAd/j+sggA7Ux8rNOMJHNJ5pPMLy4ujvNSSZpqowT3EeBIVT3Stu9jEOQvtCUS2vPxtv8osG3o9Vtb7RWqal9VzVbV7MzMzJmOX5KmzrLBXVXPA4eTvKWVdgJPAgeA3a22G7i/tQ8At7SrS3YAJ15rfVuSNJ5RPzn5G8Ank5wPPAPcyiD0702yB3gOeF/r+yBwA7AAfLf1lSRNyEjBXVWPAbOn2LXzFH0LuO0sxyVJOg0/OSlJnTG4JakzBrckdcY/66qp4KcZtZZ4xi1JnTG4JakzBrckdcbglqTOGNyS1BmDW5I6Y3BLUmcMbknqjMEtSZ0xuCWpMwa3JHXG4JakzhjcktQZg1uSOrNscCd5S5LHhh7fTvKBJBuTPJTkUHve0PonyR1JFpI8nuSqlZ+GJE2PUe7y/nRVXVFVVwBvY3AD4L8E9gIHq2o7cLBtA1wPbG+POeDOlRi4JE2rcZdKdgLfqKrngF3A/lbfD9zY2ruAT9TAF4H1STZPZLSSpLGD+ybgntbeVFXHWvt5YFNrbwEOD73mSKtJkiZg5OBOcj7wHuDPT95Xg/tCjXVvqCRzSeaTzC8uLo7zUkmaauOccV8P/ENVvdC2X1haAmnPx1v9KLBt6HVbW+0VqmpfVc1W1ezMzMz4I5ekKTVOcN/M95dJAA4Au1t7N3D/UP2WdnXJDuDE0JKKJOksjXSX9yQXAtcCvzpU/jBwb5I9wHPA+1r9QeAGYIHBFSi3Tmy0kqTRgruqvgNcfFLtRQZXmZzct4DbJjI6SdKr+MlJSeqMwS1JnTG4JakzBrckdcbglqTOGNyS1BmDW5I6Y3BLUmcMbknqjMEtSZ0xuCWpMwa3JHXG4JakzhjcktQZg1uSOmNwS1JnDG5J6ozBLUmdMbglqTMGtyR1xuCWpM4Y3JLUmVTVao+BJP8GPL3a41ghPwZ8c7UHsQKcV3/W6tzW6rx+sqpmTrVj3es9ktN4uqpmV3sQKyHJ/Fqcm/Pqz1qd21qd12txqUSSOmNwS1JnzpXg3rfaA1hBa3Vuzqs/a3Vua3Vep3VO/HJSkjS6c+WMW5I0IoNbkjqz6sGd5LokTydZSLJ3tcczjiTbkjyc5MkkX0vy/lbfmOShJIfa84ZWT5I72lwfT3LV6s7gtSU5L8lXkjzQti9N8kgb/6eTnN/qF7Tthbb/ktUc93KSrE9yX5KvJ3kqyTVr4Zgl+a32ffhEknuSvLHXY5bk40mOJ3liqDb2MUqyu/U/lGT3asxlJaxqcCc5D/g/wPXA5cDNSS5fzTGN6WXgd6rqcmAHcFsb/17gYFVtBw62bRjMc3t7zAF3vv5DHsv7gaeGtj8C3F5VbwZeAva0+h7gpVa/vfU7l30U+GxVXQa8lcEcuz5mSbYAvwnMVtVPAecBN9HvMftT4LqTamMdoyQbgQ8BPw1cDXxoKey7V1Wr9gCuAT43tP1B4IOrOaaznM/9wLUMPgW6udU2M/iAEcBdwM1D/b/X71x7AFsZ/ON4J/AAEAafTlt38rEDPgdc09rrWr+s9hxOM6+LgH8+eXy9HzNgC3AY2NiOwQPAz/d8zIBLgCfO9BgBNwN3DdVf0a/nx2ovlSx9sy050mrdaT9qXgk8AmyqqmNt1/PAptbuab5/DPwu8N9t+2LgW1X1ctseHvv35tX2n2j9z0WXAovAn7RloI8luZDOj1lVHQX+EPgX4BiDY/Aoa+OYLRn3GHVx7M7Eagf3mpDkh4G/AD5QVd8e3leD/+q7uuYyybuB41X16GqPZQWsA64C7qyqK4Hv8P0fuYFuj9kGYBeD/5h+AriQVy81rBk9HqNJWu3gPgpsG9re2mrdSPIGBqH9yar6TCu/kGRz278ZON7qvcz37cB7kjwLfIrBcslHgfVJlv6+zfDYvzevtv8i4MXXc8BjOAIcqapH2vZ9DIK892P2c8A/V9ViVf0n8BkGx3EtHLMl4x6jXo7d2FY7uL8MbG+/+T6fwS9TDqzymEaWJMDdwFNV9UdDuw4AS7/B3s1g7Xupfkv7LfgO4MTQj37njKr6YFVtrapLGByTz1fVLwEPA+9t3U6e19J839v6n5NnQ1X1PHA4yVtaaSfwJJ0fMwZLJDuS/FD7vlyaV/fHbMi4x+hzwLuSbGg/kbyr1fq32ovswA3APwHfAP73ao9nzLH/DIMf1x4HHmuPGxisFR4EDgF/C2xs/cPgKppvAF9lcAXAqs9jmTm+A3igtd8EfAlYAP4cuKDV39i2F9r+N632uJeZ0xXAfDtufwVsWAvHDPh94OvAE8CfARf0esyAexis1f8ng5+S9pzJMQJ+pc1xAbh1tec1qYcfeZekzqz2UokkaUwGtyR1xuCWpM4Y3JLUGYNbkjpjcEtSZwxuSerM/wBI6e0UvLRwIAAAAABJRU5ErkJggg==\n",
       "text/plain": [
        "<Figure size 432x288 with 1 Axes>"
       ]
@@ -124,22 +138,30 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 36,
+   "execution_count": 7,
    "metadata": {},
    "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "/Users/yeh/miniconda3/envs/dqn/lib/python3.6/site-packages/gym/logger.py:30: UserWarning: \u001b[33mWARN: You are calling 'step()' even though this environment has already returned done = True. You should always call 'reset()' once you receive 'done = True' -- any further steps are undefined behavior.\u001b[0m\n",
+      "  warnings.warn(colorize('%s: %s'%('WARN', msg % args), 'yellow'))\n"
+     ]
+    },
     {
      "data": {
       "text/plain": [
        "True"
       ]
      },
-     "execution_count": 36,
+     "execution_count": 7,
      "metadata": {},
      "output_type": "execute_result"
     },
     {
      "data": {
-      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAW4AAAD8CAYAAABXe05zAAAABHNCSVQICAgIfAhkiAAAAAlwSFlzAAALEgAACxIB0t1+/AAAADh0RVh0U29mdHdhcmUAbWF0cGxvdGxpYiB2ZXJzaW9uMy4xLjMsIGh0dHA6Ly9tYXRwbG90bGliLm9yZy+AADFEAAASMElEQVR4nO3dYYydV53f8e+vTgh0QRtCJpFrO3V211XJVsWBafAqfZEN7G6IUM1KUCWtNhaKNKkUJJBQ22QrdYNUpF2pS1aobRSvQgkVJaQLKFaULus1Qat9QcIETLAx2RiwyKyteChJAKGmTfj3xT0Dt8515s7cuR6fme9HevQ8z3nOvfd/xOWX4zPPvTdVhSSpH39nvQuQJK2MwS1JnTG4JakzBrckdcbglqTOGNyS1JmpBXeSG5I8leR4kjum9TqStNlkGvdxJ9kC/A3wW8AC8FXg5qr61pq/mCRtMtOacV8DHK+q71bV/wEeAPZO6bUkaVO5YErPuw14Zuh8AXj72TpfeumltXPnzimVIkn9OXHiBD/4wQ8y6tq0gnvUi/1/azJJ5oA5gCuuuIL5+fkplSJJ/ZmdnT3rtWktlSwAO4bOtwMnhztU1f6qmq2q2ZmZmSmVIUkbz7SC+6vAriRXJnkNcBNwYEqvJUmbylSWSqrqpSQfAL4IbAE+UVVHp/FakrTZTGuNm6p6BHhkWs8vSZuVn5yUpM4Y3JLUGYNbkjpjcEtSZwxuSeqMwS1JnTG4JakzBrckdcbglqTOGNyS1BmDW5I6Y3BLUmcMbknqjMEtSZ0xuCWpMwa3JHXG4JakzhjcktSZiX66LMkJ4MfAy8BLVTWb5BLgs8BO4ATwz6vqucnKlCQtWYsZ929W1e6qmm3ndwCHqmoXcKidS5LWyDSWSvYC97fj+4H3TOE1JGnTmjS4C/iLJE8kmWttl1fVKYC2v2zC15AkDZlojRu4tqpOJrkMOJjk2+M+sAX9HMAVV1wxYRmStHlMNOOuqpNtfxr4AnAN8GySrQBtf/osj91fVbNVNTszMzNJGZK0qaw6uJP8UpI3LB0Dvw0cAQ4A+1q3fcBDkxYpSfqFSZZKLge+kGTpef57Vf15kq8CDya5Ffg+8L7Jy5QkLVl1cFfVd4G3jGj/X8A7JilKknR2fnJSkjpjcEtSZwxuSeqMwS1JnTG4JakzBrckdcbglqTOGNyS1BmDW5I6Y3BLUmcMbknqjMEtSZ0xuCWpMwa3JHXG4JakzhjcktQZg1uSOmNwS1JnDG5J6syywZ3kE0lOJzky1HZJkoNJnm77N7b2JPl4kuNJnkzy1mkWL0mb0Tgz7k8CN5zRdgdwqKp2AYfaOcC7gF1tmwPuWZsyJUlLlg3uqvor4IdnNO8F7m/H9wPvGWr/VA18Bbg4yda1KlaStPo17sur6hRA21/W2rcBzwz1W2htr5BkLsl8kvnFxcVVliFJm89a/3EyI9pqVMeq2l9Vs1U1OzMzs8ZlSNLGtdrgfnZpCaTtT7f2BWDHUL/twMnVlydJOtNqg/sAsK8d7wMeGmq/pd1dsgd4YWlJRZK0Ni5YrkOSzwDXAZcmWQD+APhD4MEktwLfB97Xuj8C3AgcB34KvH8KNUvSprZscFfVzWe59I4RfQu4fdKiJEln5ycnJakzBrckdcbglqTOGNyS1BmDW5I6Y3BLUmcMbknqjMEtSZ0xuCWpMwa3JHXG4JakzhjcktQZg1uSOmNwS1JnDG5J6ozBLUmdMbglqTMGtyR1ZtngTvKJJKeTHBlquyvJ3yY53LYbh67dmeR4kqeS/M60CpekzWqcGfcngRtGtN9dVbvb9ghAkquAm4Bfb4/5L0m2rFWxkqQxgruq/gr44ZjPtxd4oKperKrvMfi192smqE+SdIZJ1rg/kOTJtpTyxta2DXhmqM9Ca3uFJHNJ5pPMLy4uTlCGJG0uqw3ue4BfBXYDp4A/bu0Z0bdGPUFV7a+q2aqanZmZWWUZkrT5rCq4q+rZqnq5qn4G/Cm/WA5ZAHYMdd0OnJysREnSsFUFd5KtQ6e/CyzdcXIAuCnJRUmuBHYBj09WoiRp2AXLdUjyGeA64NIkC8AfANcl2c1gGeQEcBtAVR1N8iDwLeAl4Paqenk6pUvS5rRscFfVzSOa73uV/h8FPjpJUZKks/OTk5LUGYNbkjpjcEtSZwxuSeqMwS1JnTG4JakzBrckdcbglqTOGNyS1BmDW5I6Y3BLUmcMbknqjMEtSZ0xuCWpMwa3JHXG4JakzhjcktQZg1uSOrNscCfZkeTRJMeSHE3ywdZ+SZKDSZ5u+ze29iT5eJLjSZ5M8tZpD0KSNpNxZtwvAR+uqjcDe4Dbk1wF3AEcqqpdwKF2DvAuBr/uvguYA+5Z86olaRNbNrir6lRVfa0d/xg4BmwD9gL3t273A+9px3uBT9XAV4CLk2xd88olaZNa0Rp3kp3A1cBjwOVVdQoG4Q5c1rptA54ZethCazvzueaSzCeZX1xcXHnlkrRJjR3cSV4PfA74UFX96NW6jmirVzRU7a+q2aqanZmZGbcMSdr0xgruJBcyCO1PV9XnW/OzS0sgbX+6tS8AO4Yevh04uTblSpLGuaskwH3Asar62NClA8C+drwPeGio/ZZ2d8ke4IWlJRVJ0uQuGKPPtcDvAd9Mcri1/T7wh8CDSW4Fvg+8r117BLgROA78FHj/mlYsSZvcssFdVX/N6HVrgHeM6F/A7RPWJUk6Cz85KUmdMbglqTMGtyR1xuCWpM4Y3JLUGYNbkjpjcEtSZwxuSeqMwS1JnTG4JakzBrckdcbglqTOGNyS1BmDW5I6Y3BLUmcMbknqjMGtTemJ/bfxxP7b1rsMaVXG+ekyaUMZDuzh47fN3bse5UgrNs6PBe9I8miSY0mOJvlga78ryd8mOdy2G4cec2eS40meSvI70xyAtFacgasX48y4XwI+XFVfS/IG4IkkB9u1u6vqPw53TnIVcBPw68DfA/4yyT+oqpfXsnBpNZYLZ2fg6sGyM+6qOlVVX2vHPwaOAdte5SF7gQeq6sWq+h6DX3u/Zi2Klc4l18F1vlrRGneSncDVwGPAtcAHktwCzDOYlT/HINS/MvSwBV496KVzZmkWvZJAdhau883Yd5UkeT3wOeBDVfUj4B7gV4HdwCngj5e6jnh4jXi+uSTzSeYXFxdXXLg0ibfN3fvzbSWchet8MFZwJ7mQQWh/uqo+D1BVz1bVy1X1M+BP+cVyyAKwY+jh24GTZz5nVe2vqtmqmp2ZmZlkDNJEDHD1Zpy7SgLcBxyrqo8NtW8d6va7wJF2fAC4KclFSa4EdgGPr13J0nSsZhnEANd6GGeN+1rg94BvJjnc2n4fuDnJbgbLICeA2wCq6miSB4FvMbgj5XbvKFEvhsN7NevgroHrXEjVK5afz7nZ2dman59f7zKkkVYzozbANanZ2Vnm5+dH/c3QT05Ky1nNLNw7UTRNBre0At5OqPOBXzIlrcJq7kQB/5iptWFwSxOYJMCl1XKpRFoDLqHoXDK4pTU06e2EZz6HNIpLJdKUuA6uaXHGLU2Zs3CtNWfc0jnkLFxrweCW1oF3o2gSLpVI68i7UbQaBrd0HvDLrbQSLpVI5xm/H1zLccYtnacm/XKr2dv2r/q1z4dvDdXZOeOWOvC2uXtXHMTz984xf+/clCrSejK4pY6sJLwfPjXHw6fmuOuueQN8g3GpROrMcHiPG8iDAJ/j3Vv3T7SEovODM26pY7O3jQ7ih0+NDnRDe2MY58eCX5vk8STfSHI0yUda+5VJHkvydJLPJnlNa7+onR9v13dOdwiSzgzwd281oDeycWbcLwLXV9VbgN3ADUn2AH8E3F1Vu4DngFtb/1uB56rq14C7Wz9J58BSgJ85s3731v3cddfsOlWltbbsGncN7gv6STu9sG0FXA/8i9Z+P3AXcA+wtx0D/Bnwn5KkvL9IOqeGg/qu9StDUzDWGneSLUkOA6eBg8B3gOer6qXWZQHY1o63Ac8AtOsvAG9ay6IlaTMbK7ir6uWq2g1sB64B3jyqW9uP+jn5V8y2k8wlmU8yv7i4OG69krTpreiukqp6HvgysAe4OMnSUst24GQ7XgB2ALTrvwz8cMRz7a+q2aqanZmZWV31krQJjXNXyUySi9vx64B3AseAR4H3tm77gIfa8YF2Trv+Jde3JWntjPMBnK3A/Um2MAj6B6vq4STfAh5I8h+ArwP3tf73Af8tyXEGM+2bplC3JG1a49xV8iRw9Yj27zJY7z6z/X8D71uT6iRJr+AnJyWpMwa3JHXG4JakzvjtgFInvDlLS5xxS1JnDG5J6ozBLUmdMbglqTMGtyR1xuCWpM4Y3JLUGYNbkjpjcEtSZwxuSeqMwS1JnTG4JakzBrckdcbglqTOjPNjwa9N8niSbyQ5muQjrf2TSb6X5HDbdrf2JPl4kuNJnkzy1mkPQpI2k3G+j/tF4Pqq+kmSC4G/TvI/27V/XVV/dkb/dwG72vZ24J62lyStgWVn3DXwk3Z6Ydte7Rvd9wKfao/7CnBxkq2TlypJgjHXuJNsSXIYOA0crKrH2qWPtuWQu5Nc1Nq2Ac8MPXyhtUmS1sBYwV1VL1fVbmA7cE2SfwTcCfxD4J8AlwD/tnXPqKc4syHJXJL5JPOLi4urKl6SNqMV3VVSVc8DXwZuqKpTbTnkReC/Ate0bgvAjqGHbQdOjniu/VU1W1WzMzMzqypekjajce4qmUlycTt+HfBO4NtL69ZJArwHONIecgC4pd1dsgd4oapOTaV6SdqExrmrZCtwf5ItDIL+wap6OMmXkswwWBo5DPyr1v8R4EbgOPBT4P1rX7YkbV7LBndVPQlcPaL9+rP0L+D2yUuTJI3iJyclqTMGtyR1xuCWpM4Y3JLUGYNbkjpjcEtSZwxuSeqMwS1JnTG4JakzBrckdcbglqTOGNyS1BmDW5I6Y3BLUmcMbknqjMEtSZ0xuCWpMwa3JHXG4JakzhjcktQZg1uSOmNwS1JnUlXrXQNJfgw8td51TMmlwA/Wu4gp2Kjjgo07NsfVl79fVTOjLlxwris5i6eqana9i5iGJPMbcWwbdVywccfmuDYOl0okqTMGtyR15nwJ7v3rXcAUbdSxbdRxwcYdm+PaIM6LP05KksZ3vsy4JUljWvfgTnJDkqeSHE9yx3rXs1JJPpHkdJIjQ22XJDmY5Om2f2NrT5KPt7E+meSt61f5q0uyI8mjSY4lOZrkg62967EleW2Sx5N8o43rI639yiSPtXF9NslrWvtF7fx4u75zPetfTpItSb6e5OF2vlHGdSLJN5McTjLf2rp+L05iXYM7yRbgPwPvAq4Cbk5y1XrWtAqfBG44o+0O4FBV7QIOtXMYjHNX2+aAe85RjavxEvDhqnozsAe4vf1v0/vYXgSur6q3ALuBG5LsAf4IuLuN6zng1tb/VuC5qvo14O7W73z2QeDY0PlGGRfAb1bV7qFb/3p/L65eVa3bBvwG8MWh8zuBO9ezplWOYydwZOj8KWBrO97K4D51gHuBm0f1O9834CHgtzbS2IC/C3wNeDuDD3Bc0Np//r4Evgj8Rju+oPXLetd+lvFsZxBg1wMPA9kI42o1ngAuPaNtw7wXV7qt91LJNuCZofOF1ta7y6vqFEDbX9bauxxv+2f01cBjbICxteWEw8Bp4CDwHeD5qnqpdRmu/efjatdfAN50bise258A/wb4WTt/ExtjXAAF/EWSJ5LMtbbu34urtd6fnMyIto18m0t3403yeuBzwIeq6kfJqCEMuo5oOy/HVlUvA7uTXAx8AXjzqG5t38W4krwbOF1VTyS5bql5RNeuxjXk2qo6meQy4GCSb79K397GtmLrPeNeAHYMnW8HTq5TLWvp2SRbAdr+dGvvarxJLmQQ2p+uqs+35g0xNoCqeh74MoM1/IuTLE1khmv/+bja9V8GfnhuKx3LtcA/S3ICeIDBcsmf0P+4AKiqk21/msF/bK9hA70XV2q9g/urwK72l+/XADcBB9a5prVwANjXjvcxWB9ear+l/dV7D/DC0j/1zjcZTK3vA45V1ceGLnU9tiQzbaZNktcB72Twx7xHgfe2bmeOa2m87wW+VG3h9HxSVXdW1faq2sng/0dfqqp/SefjAkjyS0nesHQM/DZwhM7fixNZ70V24EbgbxisM/679a5nFfV/BjgF/F8G/6W/lcFa4SHg6ba/pPUNg7tovgN8E5hd7/pfZVz/lME/L58EDrftxt7HBvxj4OttXEeAf9/afwV4HDgO/A/gotb+2nZ+vF3/lfUewxhjvA54eKOMq43hG207upQTvb8XJ9n85KQkdWa9l0okSStkcEtSZwxuSeqMwS1JnTG4JakzBrckdcbglqTOGNyS1Jn/B1ebj/qJ/vILAAAAAElFTkSuQmCC\n",
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAW4AAAD8CAYAAABXe05zAAAABHNCSVQICAgIfAhkiAAAAAlwSFlzAAALEgAACxIB0t1+/AAAADh0RVh0U29mdHdhcmUAbWF0cGxvdGxpYiB2ZXJzaW9uMy4xLjEsIGh0dHA6Ly9tYXRwbG90bGliLm9yZy8QZhcZAAASU0lEQVR4nO3dYYyd1X3n8e9vcSBbuouBTi2vbS1UsYJQpQAZEUepVtl4kwUaxbygCFQVl1qavKC7SVupdbovkkr7IpFWpSCtEFZIa6psEkqTxUIoWdYhWvUFNENCCYFQJhTWtgyeUOJ0E3VTtv99cc/AZbA7dzx3fH18vx/p6p7n/5x77zl67J+fOfNcP6kqJEn9+GeTHoAkaXUMbknqjMEtSZ0xuCWpMwa3JHXG4JakzqxLcCe5JsmzSRaS7F2Pz5CkaZVxX8ed5Bzgr4EPAoeBbwI3V9XTY/0gSZpS63HGfTWwUFXPV9VPgS8Cu9bhcyRpKm1Yh/fcAhwa2j4MvGd5pyRzwBzA+eef/+7LLrtsHYYiSX164YUX+MEPfpAT7VuP4B5JVe0D9gHMzs7W/Pz8pIYiSWec2dnZk+5bj6WSI8C2oe2trSZJGoP1CO5vAtuTXJrkXOAm4MA6fI4kTaWxL5VU1WtJfhP4GnAO8Lmq+u64P0eSptW6rHFX1UPAQ+vx3pI07fzmpCR1xuCWpM4Y3JLUGYNbkjpjcEtSZwxuSeqMwS1JnTG4JakzBrckdcbglqTOGNyS1BmDW5I6Y3BLUmcMbknqjMEtSZ0xuCWpMwa3JHXG4JakzqwY3Ek+l+RYkqeGahcleTjJc+35wlZPkjuTLCR5MslV6zl4SZpGo5xx/wlwzbLaXuBgVW0HDrZtgGuB7e0xB9w1nmFKkpasGNxV9b+Av11W3gXsb+39wPVD9Xtr4FFgY5LN4xqsJOnU17g3VdXR1n4J2NTaW4BDQ/0Ot5okaUzW/MvJqiqgVvu6JHNJ5pPMLy4urnUYkjQ1TjW4X15aAmnPx1r9CLBtqN/WVnuLqtpXVbNVNTszM3OKw5Ck6XOqwX0A2N3au4EHhuq3tKtLdgDHh5ZUJEljsGGlDkm+ALwf+Lkkh4FPAp8G7kuyB3gRuLF1fwi4DlgAfgLcug5jlqSptmJwV9XNJ9m18wR9C7htrYOSJJ2c35yUpM4Y3JLUGYNbkjpjcEtSZwxuSeqMwS1JnTG4JakzBrckdcbglqTOGNyS1BmDW5I6Y3BLUmcMbknqjMEtSZ0xuCWpMwa3JHXG4JakzhjcktQZg1uSOrNicCfZluSRJE8n+W6Sj7X6RUkeTvJce76w1ZPkziQLSZ5MctV6T0KSpskoZ9yvAb9TVZcDO4DbklwO7AUOVtV24GDbBrgW2N4ec8BdYx+1JE2xFYO7qo5W1bda+++AZ4AtwC5gf+u2H7i+tXcB99bAo8DGJJvHPnJJmlKrWuNOcglwJfAYsKmqjrZdLwGbWnsLcGjoZYdbbfl7zSWZTzK/uLi4ymFL0vQaObiT/Czw58DHq+pHw/uqqoBazQdX1b6qmq2q2ZmZmdW8VJKm2kjBneRtDEL781X15VZ+eWkJpD0fa/UjwLahl29tNUnSGIxyVUmAe4BnquoPh3YdAHa39m7ggaH6Le3qkh3A8aElFUnSGm0Yoc/7gF8DvpPkiVb7feDTwH1J9gAvAje2fQ8B1wELwE+AW8c6YkmacisGd1X9BZCT7N55gv4F3LbGcUmSTsJvTkpSZwxuSeqMwS1JnTG4JakzBrckdcbglqTOGNyS1BmDW5I6Y3BLUmcMbknqjMEtSZ0xuCWpMwa3JHXG4JakzhjcktQZg1uSOmNwS1JnDG5J6swoNwt+e5K/TPJXSb6b5A9a/dIkjyVZSPKlJOe2+nlte6Htv2R9pyBJ02WUM+7/C3ygqt4FXAFc0+7e/hng9qp6B/AqsKf13wO82uq3t36SpDFZMbhr4P+0zbe1RwEfAO5v9f3A9a29q23T9u9McrKbDUuSVmmkNe4k5yR5AjgGPAx8H/hhVb3WuhwGtrT2FuAQQNt/HLj4BO85l2Q+yfzi4uLaZiFJU2Sk4K6q/1dVVwBbgauBy9b6wVW1r6pmq2p2ZmZmrW8nSVNjVVeVVNUPgUeA9wIbk2xou7YCR1r7CLANoO2/AHhlLKOVJI10VclMko2t/c+BDwLPMAjwG1q33cADrX2gbdP2f72qapyDlqRptmHlLmwG9ic5h0HQ31dVDyZ5Gvhikv8MfBu4p/W/B/jTJAvA3wI3rcO4JWlqrRjcVfUkcOUJ6s8zWO9eXv974FfGMjpJ0lv4zUlJ6ozBLUmdMbglqTMGtyR1xuCWpM4Y3JLUGYNbkjpjcEtSZwxuSeqMwS1JnTG4JakzBrckdcbglqTOGNyS1BmDW5I6Y3BLUmcMbknqjMEtSZ0ZObiTnJPk20kebNuXJnksyUKSLyU5t9XPa9sLbf8l6zN0SZpOqznj/hiDu7sv+Qxwe1W9A3gV2NPqe4BXW/321k+SNCYjBXeSrcAvA59t2wE+ANzfuuwHrm/tXW2btn9n6y9JGoNRz7j/CPhd4B/b9sXAD6vqtbZ9GNjS2luAQwBt//HW/02SzCWZTzK/uLh4isOXpOmzYnAn+TBwrKoeH+cHV9W+qpqtqtmZmZlxvrUkndU2jNDnfcBHklwHvB34l8AdwMYkG9pZ9VbgSOt/BNgGHE6yAbgAeGXsI5ekKbXiGXdVfaKqtlbVJcBNwNer6leBR4AbWrfdwAOtfaBt0/Z/vapqrKOWpCm2luu4fw/47SQLDNaw72n1e4CLW/23gb1rG6IkadgoSyWvq6pvAN9o7eeBq0/Q5++BXxnD2CRJJ+A3JyWpMwa3JHXG4JakzhjcktQZg1uSOmNwS1JnDG5J6ozBLUmdMbglqTMGtyR1xuCWpM4Y3JLUGYNbkjpjcEtSZwxuSeqMwS1JnTG4JakzBrckdWak4E7yQpLvJHkiyXyrXZTk4STPtecLWz1J7kyykOTJJFet5wQkadqs5oz731bVFVU127b3AgerajtwkDduCnwtsL095oC7xjVYSdLalkp2Aftbez9w/VD93hp4FNiYZPMaPkeSNGTU4C7gfyR5PMlcq22qqqOt/RKwqbW3AIeGXnu41d4kyVyS+STzi4uLpzB0SZpOG0bs90tVdSTJzwMPJ/ne8M6qqiS1mg+uqn3APoDZ2dlVvVaSptlIZ9xVdaQ9HwO+AlwNvLy0BNKej7XuR4BtQy/f2mqSpDFYMbiTnJ/kXyy1gQ8BTwEHgN2t227ggdY+ANzSri7ZARwfWlKRJK3RKEslm4CvJFnq/9+q6qtJvgncl2QP8CJwY+v/EHAdsAD8BLh17KOWpCm2YnBX1fPAu05QfwXYeYJ6AbeNZXSSpLfwm5OS1JlRryqRuvf4vo++3n733N0THIm0Nga3ptJwiC8xzNULg1tqloe5Qa4zlcEtnYRn5TpTGdyaCicK4XG9j2Gu083g1lR499zdYwvv5Vxi0elmcGtqnChQ1yPMPSvXejO4NdUMc/XI4JaWWR6op2OJxRDXahjc0gpOx1n5yd7PQNeJGNzSKXCJRZNkcEtjMhyo67W8svy9DfHpZHBL6+BkgXo6llhmP7pvbO8/+M8+daYxuKXT6HQssczfPfeW2jjDXJNncEsTtt5LLA8eneNTn3ojzD+8eZ9B3jmDWzqDjHuJ5cGjbz37Vv8MbqkDw4Ge5ITLIaPybLt/IwV3ko3AZ4FfBAr4DeBZ4EvAJcALwI1V9WoGN6e8g8F9J38C/HpVfWvsI5em2PLwXUuQqz+jnnHfAXy1qm5Ici7wM8DvAwer6tNJ9gJ7gd8DrgW2t8d7gLvas6R1cqKz6Pm75/jw5n0ul5yFVgzuJBcA/wb4dYCq+inw0yS7gPe3bvuBbzAI7l3Ave2mwY8m2Zhkc1UdHfvoJZ3UG2H+RqjP3z3HpyYyGo3TKDcLvhRYBP44ybeTfDbJ+cCmoTB+CdjU2luAQ0OvP9xqkibM9e2zwyjBvQG4Crirqq4EfsxgWeR17ex6VVfqJ5lLMp9kfnFxcTUvlaSpNkpwHwYOV9Vjbft+BkH+cpLNAO35WNt/BNg29PqtrfYmVbWvqmaranZmZuZUxy9JU2fF4K6ql4BDSd7ZSjuBp4EDwO5W2w080NoHgFsysAM47vq2JI3PqFeV/Afg8+2KkueBWxmE/n1J9gAvAje2vg8xuBRwgcHlgLeOdcSSNOVGCu6qegKYPcGunSfoW8BtaxyXJOkkRlnjliSdQQxuSeqMwS1JnfE/mZI6480N5Bm3JHXG4JakzhjcktQZg1uSOmNwS1JnDG5J6ozBLUmdMbglqTMGtyR1xuCWpM4Y3JLUGYNbkjpjcEtSZwxuSerMisGd5J1Jnhh6/CjJx5NclOThJM+15wtb/yS5M8lCkieTXLX+05Ck6THKXd6fraorquoK4N0MbgD8FWAvcLCqtgMH2zbAtcD29pgD7lqPgUvStFrtUslO4PtV9SKwC9jf6vuB61t7F3BvDTwKbEyyeSyjlSStOrhvAr7Q2puq6mhrvwRsau0twKGh1xxuNUnSGIwc3EnOBT4C/NnyfTW4l9Kq7qeUZC7JfJL5xcXF1bxUkqbaas64rwW+VVUvt+2Xl5ZA2vOxVj8CbBt63dZWe5Oq2ldVs1U1OzMzs/qRS9KUWk1w38wbyyQAB4Ddrb0beGCofku7umQHcHxoSUWStEYj3eU9yfnAB4GPDpU/DdyXZA/wInBjqz8EXAcsMLgC5daxjVaSNFpwV9WPgYuX1V5hcJXJ8r4F3DaW0UmS3sJvTkpSZwxuSeqMwS1JnTG4JakzBrckdcbglqTOGNyS1BmDW5I6Y3BLUmcMbknqjMEtSZ0xuCWpMwa3JHXG4JakzhjcktQZg1uSOmNwS1JnDG5J6ozBLUmdMbglqTMGtyR1xuCWpM6kqiY9BpL8HfDspMexTn4O+MGkB7EOnFd/zta5na3z+tdVNXOiHRtO90hO4tmqmp30INZDkvmzcW7Oqz9n69zO1nn9U1wqkaTOGNyS1JkzJbj3TXoA6+hsnZvz6s/ZOrezdV4ndUb8clKSNLoz5YxbkjQig1uSOjPx4E5yTZJnkywk2Tvp8axGkm1JHknydJLvJvlYq1+U5OEkz7XnC1s9Se5sc30yyVWTncE/Lck5Sb6d5MG2fWmSx9r4v5Tk3FY/r20vtP2XTHLcK0myMcn9Sb6X5Jkk7z0bjlmS32p/Dp9K8oUkb+/1mCX5XJJjSZ4aqq36GCXZ3fo/l2T3JOayHiYa3EnOAf4rcC1wOXBzkssnOaZVeg34naq6HNgB3NbGvxc4WFXbgYNtGwbz3N4ec8Bdp3/Iq/Ix4Jmh7c8At1fVO4BXgT2tvgd4tdVvb/3OZHcAX62qy4B3MZhj18csyRbgPwKzVfWLwDnATfR7zP4EuGZZbVXHKMlFwCeB9wBXA59cCvvuVdXEHsB7ga8NbX8C+MQkx7TG+TwAfJDBt0A3t9pmBl8wArgbuHmo/+v9zrQHsJXBX44PAA8CYfDttA3Ljx3wNeC9rb2h9cuk53CSeV0A/M3y8fV+zIAtwCHgonYMHgT+fc/HDLgEeOpUjxFwM3D3UP1N/Xp+THqpZOkP25LDrdad9qPmlcBjwKaqOtp2vQRsau2e5vtHwO8C/9i2LwZ+WFWvte3hsb8+r7b/eOt/JroUWAT+uC0DfTbJ+XR+zKrqCPBfgP8NHGVwDB7n7DhmS1Z7jLo4dqdi0sF9Vkjys8CfAx+vqh8N76vBP/VdXXOZ5MPAsap6fNJjWQcbgKuAu6rqSuDHvPEjN9DtMbsQ2MXgH6Z/BZzPW5cazho9HqNxmnRwHwG2DW1vbbVuJHkbg9D+fFV9uZVfTrK57d8MHGv1Xub7PuAjSV4AvshgueQOYGOSpf/fZnjsr8+r7b8AeOV0DngVDgOHq+qxtn0/gyDv/Zj9O+Bvqmqxqv4B+DKD43g2HLMlqz1GvRy7VZt0cH8T2N5+830ug1+mHJjwmEaWJMA9wDNV9YdDuw4AS7/B3s1g7Xupfkv7LfgO4PjQj35njKr6RFVtrapLGByTr1fVrwKPADe0bsvntTTfG1r/M/JsqKpeAg4leWcr7QSepvNjxmCJZEeSn2l/Lpfm1f0xG7LaY/Q14ENJLmw/kXyo1fo36UV24Drgr4HvA/9p0uNZ5dh/icGPa08CT7THdQzWCg8CzwH/E7io9Q+Dq2i+D3yHwRUAE5/HCnN8P/Bga/8C8JfAAvBnwHmt/va2vdD2/8Kkx73CnK4A5ttx++/AhWfDMQP+APge8BTwp8B5vR4z4AsM1ur/gcFPSXtO5RgBv9HmuADcOul5jevhV94lqTOTXiqRJK2SwS1JnTG4JakzBrckdcbglqTOGNyS1BmDW5I68/8BGrE2KgI/IzsAAAAASUVORK5CYII=\n",
       "text/plain": [
        "<Figure size 432x288 with 1 Axes>"
       ]
@@ -159,11 +181,235 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Breakout (Atari)"
+   ]
+  },
+  {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 2,
    "metadata": {},
    "outputs": [],
-   "source": []
+   "source": [
+    "from atari_wrappers import make_atari, wrap_deepmind"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "env = gym.envs.make(\"BreakoutNoFrameskip-v4\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Action space size: 4\n"
+     ]
+    }
+   ],
+   "source": [
+    "print(f\"Action space size: {env.action_space.n}\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "observation = env.reset()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Observation space shape: (210, 160, 3)\n"
+     ]
+    }
+   ],
+   "source": [
+    "print(f\"Observation space shape: {observation.shape}\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 13,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "<matplotlib.image.AxesImage at 0x11da63fd0>"
+      ]
+     },
+     "execution_count": 13,
+     "metadata": {},
+     "output_type": "execute_result"
+    },
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAM4AAAD8CAYAAAA/rZtiAAAABHNCSVQICAgIfAhkiAAAAAlwSFlzAAALEgAACxIB0t1+/AAAADh0RVh0U29mdHdhcmUAbWF0cGxvdGxpYiB2ZXJzaW9uMy4xLjEsIGh0dHA6Ly9tYXRwbG90bGliLm9yZy8QZhcZAAAObUlEQVR4nO3df6wc1XnG8e9TE/jDSYUJ1ELYFEOdVKZqHWJRqwWUloYYK4qhf1CjKjgtqkECKRFUlQlSiypFatNgpKgtkRFWTEX4kRICqgi160ZBVWuCTRzz02CIEb4ydoEKqIlCbL/9Y85thuu7vut3dj2zy/ORVjt7ZmbnjLgPZ/Z49l1FBGZ2bH6p7Q6YjSIHxyzBwTFLcHDMEhwcswQHxyxhaMGRtEzSTkm7JK0Z1nHM2qBh/DuOpFnAC8CngT3AE8CVEfHswA9m1oJhjTjnA7si4uWIeA+4F1gxpGOZHXcnDOl9zwBerb3eA/x2r40l+fYF66LXI+K06VYMKzgzkrQaWN3W8c368EqvFcMKzgQwv/Z6Xmn7fxGxDlgHHnFs9AzrM84TwEJJCySdCKwEHh7SscyOu6GMOBFxUNL1wL8Cs4D1EfHMMI5l1oahTEcfcyc6eKm2du3aY97nhhtuaPQeU/cf1Hs01YU+TDW1T0M65raIWDLdCt85YJbQ2qzaqBnGaNDGqDYIx2NE6TqPOGYJHnHsmM00yn0QRiSPOGYJHnFsRjONIG18zmqbRxyzBI84fRrE/1W78h6jcMyu84hjluDgmCX4lhuz3nzLjdkgdWJyYN68eR+IfzSz0XK0v0mPOGYJDo5ZgoNjluDgmCWkgyNpvqTvS3pW0jOSvljab5E0IWl7eSwfXHfNuqHJrNpB4MaIeFLSR4BtkjaVdbdFxNead8+sm9LBiYi9wN6y/I6k56gKEZqNvYF8xpF0FvAJ4PHSdL2kHZLWS5oziGOYdUnj4Ej6MPAA8KWIeBu4HTgHWEw1It3aY7/VkrZK2nrgwIGm3TA7rhoFR9KHqEJzd0R8ByAi9kXEoYg4DNxBVYD9CBGxLiKWRMSS2bNnN+mG2XHXZFZNwJ3AcxGxttZ+em2zy4Gn890z66Yms2q/C3weeErS9tL2ZeBKSYuBAHYD1zTqoVkHNZlV+w9A06x6JN8ds9HgOwfMEjrxtYKZ+CsHNgxNail4xDFLcHDMEhwcswQHxyzBwTFLcHDMEhwcswQHxyzBwTFLcHDMEhwcswQHxyzBwTFLcHDMEhwcs4TG38eRtBt4BzgEHIyIJZJOAe4DzqL6+vQVEfE/TY9l1hWDGnF+LyIW1369ag2wOSIWApvLa7OxMaxLtRXAhrK8AbhsSMcxa8UgghPARknbJK0ubXNLiVyA14C5AziOWWcMoubABRExIelXgE2Snq+vjIiY7sdxS8hWA8yZ4yq5NloajzgRMVGe9wMPUlXu3DdZmLA8759mP1fytJHVtATu7PITH0iaDVxCVbnzYWBV2WwV8FCT45h1TdNLtbnAg1U1XE4AvhURj0p6Arhf0tXAK8AVDY9j1imNghMRLwO/NU37G8DFTd7brMt854BZwkhU8tyybFnbXbAx9J8N9vWIY5bg4JglODhmCQ6OWYKDY5YwErNqh3/t7ba7YPY+HnHMEhwcswQHxyzBwTFLcHDMEhwcs4SRmI5+85ffbbsLZu/jEccswcExS0hfqkn6OFW1zklnA38JnAz8GfDfpf3LEfFIuodmHZQOTkTsBBYDSJoFTFBVufkT4LaI+NpAemjWQYO6VLsYeCkiXhnQ+5l12qBm1VYC99ReXy/pKmArcGPTgutv/vp7TXY3m97r+V0bjziSTgQ+B3y7NN0OnEN1GbcXuLXHfqslbZW09cCBA027YXZcDeJS7VLgyYjYBxAR+yLiUEQcBu6gqux5BFfytFE2iOBcSe0ybbL0bXE5VWVPs7HS6DNOKXv7aeCaWvNXJS2m+hWD3VPWmY2FppU8DwAfndL2+UY9MhsBI3Gv2rcOn9l2F2wMXdJgX99yY5bg4JglODhmCQ6OWYKDY5YwErNq7917S9tdsHF0Sf6HPjzimCU4OGYJDo5ZgoNjluDgmCU4OGYJIzEd/e+PLm27CzaGPnvJ2vS+HnHMEhwcswQHxyyhr+BIWi9pv6Sna22nSNok6cXyPKe0S9LXJe2StEPSecPqvFlb+h1xvgksm9K2BtgcEQuBzeU1VFVvFpbHaqpyUWZjpa/gRMRjwJtTmlcAG8ryBuCyWvtdUdkCnDyl8o3ZyGvyGWduROwty68Bc8vyGcCrte32lLb3cUFCG2UDmRyIiKAqB3Us+7ggoY2sJsHZN3kJVp73l/YJYH5tu3mlzWxsNAnOw8CqsrwKeKjWflWZXVsKvFW7pDMbC33dciPpHuBTwKmS9gB/BfwNcL+kq4FXgCvK5o8Ay4FdwLtUv5djNlb6Ck5EXNlj1cXTbBvAdU06ZdZ1vnPALMHBMUtwcMwSHByzBAfHLMHBMUtwcMwSHByzBAfHLMHBMUtwcMwSHByzBAfHLMHBMUtwcMwSHByzBAfHLGHG4PSo4vl3kp4vlToflHRyaT9L0k8lbS+Pbwyz82Zt6WfE+SZHVvHcBPxGRPwm8AJwU23dSxGxuDyuHUw3zbplxuBMV8UzIjZGxMHycgtVCSizD4xBfMb5U+B7tdcLJP1I0g8kXdhrJ1fytFHW6BfZJN0MHATuLk17gTMj4g1JnwS+K+nciHh76r4RsQ5YBzB//vxjqgJq1rb0iCPpC8BngT8uJaGIiJ9FxBtleRvwEvCxAfTTrFNSwZG0DPgL4HMR8W6t/TRJs8ry2VQ/9fHyIDpq1iUzXqr1qOJ5E3ASsEkSwJYyg3YR8NeSfg4cBq6NiKk/D2I28mYMTo8qnnf22PYB4IGmnTLrOt85YJbg4JglODhmCQ6OWYKDY5bg4JglODhmCQ6OWYKDY5bg4JglODhmCQ6OWYKDY5bg4JglODhmCQ6OWYKDY5aQreR5i6SJWsXO5bV1N0naJWmnpM8Mq+NmbcpW8gS4rVax8xEASYuAlcC5ZZ9/nCzeYTZOUpU8j2IFcG8pE/UTYBdwfoP+mXVSk88415ei6+slzSltZwCv1rbZU9qO4EqeNsqywbkdOAdYTFW989ZjfYOIWBcRSyJiyezZs5PdMGtHKjgRsS8iDkXEYeAOfnE5NgHMr206r7SZjZVsJc/Tay8vByZn3B4GVko6SdICqkqeP2zWRbPuyVby/JSkxUAAu4FrACLiGUn3A89SFWO/LiIODafrZu0ZaCXPsv1XgK806ZRZ1/nOAbMEB8cswcExS3BwzBIcHLMEB8cswcExS3BwzBIcHLMEB8cswcExS3BwzBIcHLMEB8cswcExS3BwzBKyBQnvqxUj3C1pe2k/S9JPa+u+MczOm7Vlxm+AUhUk/HvgrsmGiPijyWVJtwJv1bZ/KSIWD6qDZl3Uz1enH5N01nTrJAm4Avj9wXbLrNuafsa5ENgXES/W2hZI+pGkH0i6sOH7m3VSP5dqR3MlcE/t9V7gzIh4Q9Inge9KOjci3p66o6TVwGqAOXPmTF1t1mnpEUfSCcAfAvdNtpWa0W+U5W3AS8DHptvflTxtlDW5VPsD4PmI2DPZIOm0yV8nkHQ2VUHCl5t10ax7+pmOvgf4L+DjkvZIurqsWsn7L9MALgJ2lOnpfwaujYh+f+nAbGRkCxISEV+Ypu0B4IHm3TLrNt85YJbg4JglODhmCQ6OWYKDY5bg4JglODhmCQ6OWYKDY5bQ9O7ogXhr1mH+5eT/bbsbNo0ty5Y12n/po48OqCeD9zsbN6b39YhjluDgmCU4OGYJnfiMY93V5c8obfKIY5bgEcc+sJqMpoqIAXYl2Qmp/U6YHWlbRCyZbkU/X52eL+n7kp6V9IykL5b2UyRtkvRieZ5T2iXp65J2Sdoh6bzBnotZ+/r5jHMQuDEiFgFLgeskLQLWAJsjYiGwubwGuJSqSMdCqvJPtw+812YtmzE4EbE3Ip4sy+8AzwFnACuADWWzDcBlZXkFcFdUtgAnSzp94D03a9ExzaqVUrifAB4H5kbE3rLqNWBuWT4DeLW2257SZjY2+p5Vk/Rhqgo2X4qIt6uy0ZWIiGP9gF+v5Gk2avoacSR9iCo0d0fEd0rzvslLsPK8v7RPAPNru88rbe9Tr+SZ7bxZW/qZVRNwJ/BcRKytrXoYWFWWVwEP1dqvKrNrS4G3apd0ZuMhIo76AC4AAtgBbC+P5cBHqWbTXgT+DTilbC/gH6jqRj8FLOnjGOGHHx18bO31N+t/ADXrLf8PoGZ2JAfHLMHBMUtwcMwSHByzhK58H+d14EB5HhenMj7nM07nAv2fz6/2WtGJ6WgASVvH6S6CcTqfcToXGMz5+FLNLMHBMUvoUnDWtd2BARun8xmnc4EBnE9nPuOYjZIujThmI6P14EhaJmlnKe6xZuY9ukfSbklPSdouaWtpm7aYSRdJWi9pv6Sna20jW4ylx/ncImmi/DfaLml5bd1N5Xx2SvpMXweZ6Zb/YT6AWVRfPzgbOBH4MbCozT4lz2M3cOqUtq8Ca8ryGuBv2+7nUfp/EXAe8PRM/af6Ssn3qL4+shR4vO3+93k+twB/Ps22i8rf3UnAgvL3OGumY7Q94pwP7IqIlyPiPeBeqmIf46BXMZPOiYjHgDenNI9sMZYe59PLCuDeiPhZRPwE2EX1d3lUbQdnXAp7BLBR0rZSSwF6FzMZFeNYjOX6cnm5vnbpnDqftoMzLi6IiPOoaspdJ+mi+sqorglGdvpy1Ptf3A6cAywG9gK3NnmztoPTV2GProuIifK8H3iQaqjvVcxkVDQqxtI1EbEvIg5FxGHgDn5xOZY6n7aD8wSwUNICSScCK6mKfYwMSbMlfWRyGbgEeJrexUxGxVgVY5nyOexyqv9GUJ3PSkknSVpAVYH2hzO+YQdmQJYDL1DNZtzcdn8S/T+balbmx8Azk+dAj2ImXXwA91Bdvvyc6hr/6l79J1GMpSPn80+lvztKWE6vbX9zOZ+dwKX9HMN3DpgltH2pZjaSHByzBAfHLMHBMUtwcMwSHByzBAfHLMHBMUv4P71iQQABIm4FAAAAAElFTkSuQmCC\n",
+      "text/plain": [
+       "<Figure size 432x288 with 1 Axes>"
+      ]
+     },
+     "metadata": {
+      "needs_background": "light"
+     },
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "plt.figure()\n",
+    "plt.imshow(env.render(mode='rgb_array'))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Add wrappers around environment to emulate deepmind atari processing steps"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "env2 = make_atari(\"BreakoutNoFrameskip-v4\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "env2 = wrap_deepmind(env2, frame_stack=True, scale=False)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "obs2 = env2.reset()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 10,
+   "metadata": {},
+   "outputs": [
+    {
+     "ename": "AttributeError",
+     "evalue": "'LazyFrames' object has no attribute 'shape'",
+     "output_type": "error",
+     "traceback": [
+      "\u001b[0;31m---------------------------------------------------------------------------\u001b[0m",
+      "\u001b[0;31mAttributeError\u001b[0m                            Traceback (most recent call last)",
+      "\u001b[0;32m<ipython-input-10-e9516f71e798>\u001b[0m in \u001b[0;36m<module>\u001b[0;34m\u001b[0m\n\u001b[0;32m----> 1\u001b[0;31m \u001b[0mprint\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0;34mf\"Observation space shape: {obs2.shape}\"\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m",
+      "\u001b[0;31mAttributeError\u001b[0m: 'LazyFrames' object has no attribute 'shape'"
+     ]
+    }
+   ],
+   "source": [
+    "print(f\"Observation space shape: {obs2.shape}\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 11,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "4"
+      ]
+     },
+     "execution_count": 11,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "# frames will make up 4 channels\n",
+    "len(obs2._frames)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 12,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "(84, 84, 1)"
+      ]
+     },
+     "execution_count": 12,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "# dimensions of a single frame\n",
+    "obs2._frames[0].shape"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 14,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "<matplotlib.image.AxesImage at 0x11de5bfd0>"
+      ]
+     },
+     "execution_count": 14,
+     "metadata": {},
+     "output_type": "execute_result"
+    },
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAM4AAAD8CAYAAAA/rZtiAAAABHNCSVQICAgIfAhkiAAAAAlwSFlzAAALEgAACxIB0t1+/AAAADh0RVh0U29mdHdhcmUAbWF0cGxvdGxpYiB2ZXJzaW9uMy4xLjEsIGh0dHA6Ly9tYXRwbG90bGliLm9yZy8QZhcZAAAOf0lEQVR4nO3df6wc1XnG8e9TE/jDSYUJ1ELYFEOdVFC1DrGo1QJKS0OMFcXQP6hRFZwW1SCBlAiqygSpRZUitWkwUtSWyAgrpiIGUkJAFXFx3Sioak2wiWN+GgwxwlfGLlABNVGI7bd/zLnNcH3Xd/3Ormd2eT7SamfPzOycEffhzB7PvquIwMyOzS+13QGzUeTgmCU4OGYJDo5ZgoNjluDgmCUMLTiSlkraKWmXpNXDOo5ZGzSMf8eRNAt4Afg0sAd4ArgqIp4d+MHMWjCsEecCYFdEvBwR7wH3AsuHdCyz4+6EIb3vGcCrtdd7gN/utbEk375gXfR6RJw23YphBWdGklYBq9o6vlkfXum1YljBmQDm117PK23/LyLWAmvBI46NnmF9xnkCWChpgaQTgRXAw0M6ltlxN5QRJyIOSroB+FdgFrAuIp4ZxrHM2jCU6ehj7kQHL9XWrFlzzPvceOONjd5j6v6Deo+mutCHqab2aUjH3BYRi6db4TsHzBJam1UbNcMYDdoY1QbheIwoXecRxyzBI44ds5lGuQ/CiOQRxyzBI47NaKYRpI3PWW3ziGOW4BGnT4P4v2pX3mMUjtl1HnHMEhwcswTfcmPWm2+5MRukTkwOzJs37wPxj2Y2Wo72N+kRxyzBwTFLcHDMEhwcs4R0cCTNl/R9Sc9KekbSF0v7rZImJG0vj2WD665ZNzSZVTsI3BQRT0r6CLBN0qay7vaI+Frz7pl1Uzo4EbEX2FuW35H0HFUhQrOxN5DPOJLOAj4BPF6abpC0Q9I6SXMGcQyzLmkcHEkfBh4AvhQRbwN3AOcAi6hGpNt67LdK0lZJWw8cONC0G2bHVaPgSPoQVWjuiYjvAETEvog4FBGHgTupCrAfISLWRsTiiFg8e/bsJt0wO+6azKoJuAt4LiLW1NpPr212BfB0vntm3dRkVu13gc8DT0naXtq+DFwlaREQwG7g2kY9NOugJrNq/wFomlWP5LtjNhp854BZQie+VjATf+XAhqFJLQWPOGYJDo5ZgoNjluDgmCU4OGYJDo5ZgoNjluDgmCU4OGYJDo5ZgoNjluDgmCU4OGYJDo5ZgoNjltD4+ziSdgPvAIeAgxGxWNIpwH3AWVRfn74yIv6n6bHMumJQI87vRcSi2q9XrQY2R8RCYHN5bTY2hnWpthxYX5bXA5cP6ThmrRhEcAJ4VNI2SatK29xSIhfgNWDuAI5j1hmDqDlwYURMSPoVYJOk5+srIyKm+3HcErJVAHPmuEqujZbGI05ETJTn/cCDVJU7900WJizP+6fZz5U8bWQ1LYE7u/zEB5JmA5dSVe58GFhZNlsJPNTkOGZd0/RSbS7wYFUNlxOAb0XERklPAPdLugZ4Bbiy4XHMOqVRcCLiZeC3pml/A7ikyXubdZnvHDBLGIlKnluWLm27CzaG/rPBvh5xzBIcHLMEB8cswcExS3BwzBJGYlbt8K+93XYXzN7HI45ZgoNjluDgmCU4OGYJDo5ZgoNjljAS09Fv/vK7bXfB7H084pglODhmCelLNUkfp6rWOels4C+Bk4E/A/67tH85Ih5J99Csg9LBiYidwCIASbOACaoqN38C3B4RXxtID806aFCXapcAL0XEKwN6P7NOG9Ss2gpgQ+31DZKuBrYCNzUtuP7mr7/XZHez6b2e37XxiCPpROBzwLdL0x3AOVSXcXuB23rst0rSVklbDxw40LQbZsfVIC7VLgOejIh9ABGxLyIORcRh4E6qyp5HcCVPG2WDCM5V1C7TJkvfFldQVfY0GyuNPuOUsrefBq6tNX9V0iKqXzHYPWWd2VhoWsnzAPDRKW2fb9QjsxEwEveqfevwmW13wcbQpQ329S03ZgkOjlmCg2OW4OCYJTg4ZgkjMav23r23tt0FG0eX5n/owyOOWYKDY5bg4JglODhmCQ6OWYKDY5YwEtPR/75xSdtdsDH02UvXpPf1iGOW4OCYJTg4Zgl9BUfSOkn7JT1daztF0iZJL5bnOaVdkr4uaZekHZLOH1bnzdrS74jzTWDplLbVwOaIWAhsLq+hqnqzsDxWUZWLMhsrfQUnIh4D3pzSvBxYX5bXA5fX2u+Oyhbg5CmVb8xGXpPPOHMjYm9Zfg2YW5bPAF6tbbentL2PCxLaKBvI5EBEBFU5qGPZxwUJbWQ1Cc6+yUuw8ry/tE8A82vbzSttZmOjSXAeBlaW5ZXAQ7X2q8vs2hLgrdolndlY6OuWG0kbgE8Bp0raA/wV8DfA/ZKuAV4BriybPwIsA3YB71L9Xo7ZWOkrOBFxVY9Vl0yzbQDXN+mUWdf5zgGzBAfHLMHBMUtwcMwSHByzBAfHLMHBMUtwcMwSHByzBAfHLMHBMUtwcMwSHByzBAfHLMHBMUtwcMwSHByzhBmD06OK599Jer5U6nxQ0sml/SxJP5W0vTy+MczOm7WlnxHnmxxZxXMT8BsR8ZvAC8DNtXUvRcSi8rhuMN0065YZgzNdFc+IeDQiDpaXW6hKQJl9YAziM86fAt+rvV4g6UeSfiDpol47uZKnjbJGv8gm6RbgIHBPadoLnBkRb0j6JPBdSedFxNtT942ItcBagPnz5x9TFVCztqVHHElfAD4L/HEpCUVE/Cwi3ijL24CXgI8NoJ9mnZIKjqSlwF8An4uId2vtp0maVZbPpvqpj5cH0VGzLpnxUq1HFc+bgZOATZIAtpQZtIuBv5b0c+AwcF1ETP15EGvJlqXV5OiSjRtb7snomzE4Pap43tVj2weAB5p2yqzrfOeAWYKDY5bQaDraRos/2wyORxyzBAfHLMHBMUtwcMwSHByzBAfHLMHBMUtwcMwSHByzBAfHLMHBMUtwcMwSHByzBAfHLCFbyfNWSRO1ip3LautulrRL0k5JnxlWx83alK3kCXB7rWLnIwCSzgVWAOeVff5xsniH2ThJVfI8iuXAvaVM1E+AXcAFDfpn1klNPuPcUIqur5M0p7SdAbxa22ZPaTuCK3naKMsG5w7gHGARVfXO2471DSJibUQsjojFs2fPTnbDrB2p4ETEvog4FBGHgTv5xeXYBDC/tum80mY2VrKVPE+vvbwCmJxxexhYIekkSQuoKnn+sFkXzbonW8nzU5IWAQHsBq4FiIhnJN0PPEtVjP36iDg0nK6btWeglTzL9l8BvtKkU2Zd5zsHzBIcHLMEB8cswcExS3BwzBIcHLMEB8cswcExS3BwzBIcHLMEB8cswcExS3BwzBIcHLMEB8cswcExS8gWJLyvVoxwt6Ttpf0sST+trfvGMDtv1pYZvwFKVZDw74G7Jxsi4o8mlyXdBrxV2/6liFg0qA6adVE/X51+TNJZ062TJOBK4PcH2y2zbmv6GeciYF9EvFhrWyDpR5J+IOmihu9v1kn9XKodzVXAhtrrvcCZEfGGpE8C35V0XkS8PXVHSauAVQBz5syZutqs09IjjqQTgD8E7ptsKzWj3yjL24CXgI9Nt78redooa3Kp9gfA8xGxZ7JB0mmTv04g6WyqgoQvN+uiWff0Mx29Afgv4OOS9ki6pqxawfsv0wAuBnaU6el/Bq6LiH5/6cBsZGQLEhIRX5im7QHggebdMus23zlgluDgmCU4OGYJDo5ZgoNjluDgmCU4OGYJDo5ZgoNjltD07uiBeGvWYf7l5P9tuxs2AFuWLm38Hks2bhxAT2b2O48+mt7XI45ZgoNjluDgmCV04jOOjY/j9fmkbR5xzBI84tgHVpPRURExwK4kOyG13wmzI22LiMXTrejnq9PzJX1f0rOSnpH0xdJ+iqRNkl4sz3NKuyR9XdIuSTsknT/YczFrXz+fcQ4CN0XEucAS4HpJ5wKrgc0RsRDYXF4DXEZVpGMhVfmnOwbea7OWzRiciNgbEU+W5XeA54AzgOXA+rLZeuDysrwcuDsqW4CTJZ0+8J6bteiYZtVKKdxPAI8DcyNib1n1GjC3LJ8BvFrbbU9pMxsbfc+qSfowVQWbL0XE21XZ6EpExLF+wK9X8jQbNX2NOJI+RBWaeyLiO6V53+QlWHneX9ongPm13eeVtvepV/LMdt6sLf3Mqgm4C3guItbUVj0MrCzLK4GHau1Xl9m1JcBbtUs6s/EQEUd9ABcCAewAtpfHMuCjVLNpLwL/BpxSthfwD1R1o58CFvdxjPDDjw4+tvb6m/U/gJr1lv8HUDM7koNjluDgmCU4OGYJDo5ZQle+j/M6cKA8j4tTGZ/zGadzgf7P51d7rejEdDSApK3jdBfBOJ3POJ0LDOZ8fKlmluDgmCV0KThr2+7AgI3T+YzTucAAzqczn3HMRkmXRhyzkdF6cCQtlbSzFPdYPfMe3SNpt6SnJG2XtLW0TVvMpIskrZO0X9LTtbaRLcbS43xulTRR/httl7Sstu7mcj47JX2mr4PMdMv/MB/ALKqvH5wNnAj8GDi3zT4lz2M3cOqUtq8Cq8vyauBv2+7nUfp/MXA+8PRM/af6Ssn3qL4+sgR4vO3+93k+twJ/Ps2255a/u5OABeXvcdZMx2h7xLkA2BURL0fEe8C9VMU+xkGvYiadExGPAW9OaR7ZYiw9zqeX5cC9EfGziPgJsIvq7/Ko2g7OuBT2COBRSdtKLQXoXcxkVIxjMZYbyuXlutqlc+p82g7OuLgwIs6nqil3vaSL6yujuiYY2enLUe9/cQdwDrAI2Avc1uTN2g5OX4U9ui4iJsrzfuBBqqG+VzGTUdGoGEvXRMS+iDgUEYeBO/nF5VjqfNoOzhPAQkkLJJ0IrKAq9jEyJM2W9JHJZeBS4Gl6FzMZFWNVjGXK57ArqP4bQXU+KySdJGkBVQXaH874hh2YAVkGvEA1m3FL2/1J9P9sqlmZHwPPTJ4DPYqZdPEBbKC6fPk51TX+Nb36T6IYS0fO559Kf3eUsJxe2/6Wcj47gcv6OYbvHDBLaPtSzWwkOThmCQ6OWYKDY5bg4JglODhmCQ6OWYKDY5bwfwc5Raq3nQqaAAAAAElFTkSuQmCC\n",
+      "text/plain": [
+       "<Figure size 432x288 with 1 Axes>"
+      ]
+     },
+     "metadata": {
+      "needs_background": "light"
+     },
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "plt.figure()\n",
+    "plt.imshow(env2.render(mode='rgb_array'))"
+   ]
   },
   {
    "cell_type": "code",

--- a/DQN/nnetworks.py
+++ b/DQN/nnetworks.py
@@ -25,13 +25,13 @@ class MLPQFunction(nn.Module):
 
     def forward(self, obs):
         q = self.q(obs)
-        return torch.squeeze(q, -1) # Critical to ensure q has right shape.
+        return torch.squeeze(q, -1)  # Critical to ensure q has right shape.
 
 
 # TODO: Consider removing this class entirely and handling `act` in dqn logic instead.
 class MLPCritic(nn.Module):
-    def __init__(self, observation_space, action_space, 
-                 hidden_sizes=(256,256),
+    def __init__(self, observation_space, action_space,
+                 hidden_sizes=(256, 256),
                  activation=nn.ReLU):
         super().__init__()
         obs_dim = observation_space.shape[0]
@@ -43,7 +43,7 @@ class MLPCritic(nn.Module):
     def act(self, obs):
         """Return an action (an integer)"""
         with torch.no_grad():
-            a = torch.argmax(self.q(obs)).numpy()
+            a = torch.argmax(self.q(obs)).cpu().numpy()
             return a
 
 
@@ -121,6 +121,5 @@ class CNNCritic(nn.Module):
         """Return an action (an integer)"""
         with torch.no_grad():
             obs = torch.unsqueeze(obs, 0)
-            a = np.argmax(self.q(obs)).numpy()
+            a = torch.argmax(self.q(obs)).cpu().numpy()
             return a
-        

--- a/DQN/nnetworks.py
+++ b/DQN/nnetworks.py
@@ -67,19 +67,39 @@ class CNNQFunction(nn.Module):
     ----
     nA: number of actions
     """
-    def __init__(self, act_dim):
+    def __init__(self, act_dim, w=84, h=84, num_channels=4):
         super().__init__()
-        self.conv1 = nn.Conv2d(1, 32, kernel_size=8, stride=4)
+        self.conv1 = nn.Conv2d(num_channels, 32, kernel_size=8, stride=4)
         self.conv2 = nn.Conv2d(32, 64, kernel_size=4, stride=2)
         self.conv3 = nn.Conv2d(64, 64, kernel_size=3, stride=1)
-        self.fc1 = nn.Linear(64, 512)
+
+        # Number of Linear input connections depends on output of conv2d layers
+        # and therefore the input image size, so compute it.
+        def conv2d_size_out(size, kernel_size, stride):
+            return (size - (kernel_size - 1) - 1) // stride  + 1
+        self._convw = conv2d_size_out(conv2d_size_out(conv2d_size_out(w, kernel_size=8, stride=4),
+                                                      kernel_size=4,
+                                                      stride=2),
+                                      kernel_size=3,
+                                      stride=1)
+        self._convh = conv2d_size_out(conv2d_size_out(conv2d_size_out(h, kernel_size=8, stride=4),
+                                                      kernel_size=4,
+                                                      stride=2),
+                                      kernel_size=3,
+                                      stride=1)
+        linear_input_size = self._convw * self._convh * 64  # 7*7*64 for Atari
+
+        self.fc1 = nn.Linear(linear_input_size, 512)
         self.fc2 = nn.Linear(512, act_dim)
 
     def forward(self, obs):
-        x = obs.view(-1, 84, 84, 4)
+        # Input has shape (batch size, width, height, num channels),
+        # want shape (batch size, num channels, width, height).
+        x = obs.permute(0, 3, 1, 2)
         x = F.relu(self.conv1(x))
         x = F.relu(self.conv2(x))
         x = F.relu(self.conv3(x))
+        x = x.view(-1, 64 * self._convw * self._convh)
         x = F.relu(self.fc1(x))
         q = self.fc2(x)
         return torch.squeeze(q, -1)  # Ensure q has right shape.
@@ -88,16 +108,19 @@ class CNNQFunction(nn.Module):
 class CNNCritic(nn.Module):
     def __init__(self, observation_space, action_space):
         super().__init__()
-        # TODO: do I need observation_space?
-        obs_dim = observation_space.shape[0]
+        width = observation_space.shape[0]
+        height = observation_space.shape[1]
+        num_channels = observation_space.shape[2]
+        # obs_num_channels = 4 for atari using frame_stack=True
         act_dim = action_space.n  # assumes Discrete space
 
         # build value function
-        self.q = CNNQFunction(act_dim)
+        self.q = CNNQFunction(act_dim, width, height, num_channels)
 
     def act(self, obs):
         """Return an action (an integer)"""
         with torch.no_grad():
+            obs = torch.unsqueeze(obs, 0)
             a = np.argmax(self.q(obs)).numpy()
             return a
         


### PR DESCRIPTION
- add Atari wrappers copied from openai/baselines
- Fix CNN for reading in Atari images
- Add gpu compatibility

TODO:
- Add monitor wrapper without video recording and log unclipped rewards for comparison to baselines performance
- clean up some tensor manipulations, e.g. gratuitous `squeeze`, use `flatten` instead of `view` for input from convolutional layer to linear layer