### PR TITLE
Monitor logging

### DIFF
--- a/DQN/dqn.py
+++ b/DQN/dqn.py
@@ -331,6 +331,8 @@ def dqn(env_fn, actor_critic=MLPCritic, replay_size=500,
 
 
 # =========== BreakoutNoFrameskip-v0 hyperparameters ===========
+
+# for testing
 # wandb_config = dict(
 #     replay_size = 20_000,
 #     seed = 0,
@@ -351,20 +353,19 @@ def dqn(env_fn, actor_critic=MLPCritic, replay_size=500,
 # )
 
 wandb_config = dict(
-    replay_size = 20_000,
+    replay_size = 1_000_000,
     seed = 0,
     steps_per_epoch = 80*32,
-    #epochs = 100,
-    epochs = int(1e7 / 640),
+    epochs = 2000,
     gamma = 0.99,
     lr = 0.00025,
-    batch_size = 64,
-    start_steps = 10_000,
-    update_after = 10_000,
+    batch_size = 32,
+    start_steps = 50_000,
+    update_after = 50_000,
     update_every = 4,
     epsilon_start = 1.0,
     epsilon_end = 0.1,
-    epsilon_step = 4e-5,
+    epsilon_step = 1e-7,
     target_update_every = 10_000,
     max_ep_len = 27000
 )
@@ -373,7 +374,7 @@ addl_config = dict(
     actor_critic=CNNCritic,
     record_video = False,
     record_video_every = 2000,
-    save_freq = 100
+    save_freq = 150
 )
 
 # =========== CartPole-v1 hyperparameters ===========

--- a/DQN/dqn.py
+++ b/DQN/dqn.py
@@ -243,16 +243,6 @@ def dqn(env_fn, actor_critic=MLPCritic, replay_size=500,
             a = ac.act(torch.as_tensor(o, dtype=torch.float32, device=device))
         return a
 
-    def test_agent():
-        for j in range(num_test_episodes):
-            o, d, ep_ret, ep_len = test_env.reset(), False, 0, 0
-            while not(d or (ep_len == max_ep_len)):
-                # Take deterministic actions at test time (noise_scale=0)
-                o, r, d, _ = test_env.step(get_action(o, 0))
-                ep_ret += r
-                ep_len += 1
-            logger.store(TestEpRet=ep_ret, TestEpLen=ep_len)
-
     # main loop: collect experience in env
 
     # Initialize experience replay buffer
@@ -319,14 +309,10 @@ def dqn(env_fn, actor_critic=MLPCritic, replay_size=500,
             if (epoch % save_freq == 0) or (epoch == epochs):
                 logger.save_state({'env': env}, None)
 
-            # Test the performance of the deterministic version of the agent.
-            test_agent()
-
             # Log info about epoch
             logger.log_tabular('Epoch', epoch)
             logger.log_tabular('EpRet', with_min_and_max=True)  # will error if episode lasts longer than epoch since no returns stored
             logger.log_tabular('EpLen', average_only=True)
-            logger.log_tabular('TestEpRet', with_min_and_max=True)
             logger.log_tabular('TotalEnvInteracts', t)
             logger.log_tabular('QVals', with_min_and_max=True)  # will throw KeyError if update period < epoch period
             logger.log_tabular('LossQ', average_only=True)


### PR DESCRIPTION
WIP -- Adding monitor to access raw (unclipped rewards) via Monitor's `StatsRecorder` object (https://github.com/openai/gym/blob/master/gym/wrappers/monitoring/stats_recorder.py).  Running into errors where monitor complains episode is done, but env is attempting to step, e.g.
```
Traceback (most recent call last):
  File "dqn.py", line 438, in <module>
    dqn(lambda: env, **wandb_config, **addl_config)
  File "dqn.py", line 276, in dqn
    o2, r, d, _ = env.step(a)
  File "/Users/yeh/sandbox/rl/reinforcement-learning/DQN/atari_wrappers.py", line 236, in step
    ob, reward, done, info = self.env.step(action)
  File "/Users/yeh/.local/share/virtualenvs/DQN-50XYwH7O/lib/python3.7/site-packages/gym/core.py", line 275, in step
    observation, reward, done, info = self.env.step(action)
  File "/Users/yeh/.local/share/virtualenvs/DQN-50XYwH7O/lib/python3.7/site-packages/gym/core.py", line 263, in step
    observation, reward, done, info = self.env.step(action)
  File "/Users/yeh/sandbox/rl/reinforcement-learning/DQN/atari_wrappers.py", line 81, in step
    return self.env.step(ac)
  File "/Users/yeh/sandbox/rl/reinforcement-learning/DQN/atari_wrappers.py", line 94, in step
    obs, reward, done, info = self.env.step(action)
  File "/Users/yeh/.local/share/virtualenvs/DQN-50XYwH7O/lib/python3.7/site-packages/gym/wrappers/monitor.py", line 30, in step
    self._before_step(action)
  File "/Users/yeh/.local/share/v

########### error generated on a different run (similar but not identical)
Traceback (most recent call last):
  File "dqn.py", line 438, in <module>
    dqn(lambda: env, **wandb_config, **addl_config)
  File "dqn.py", line 322, in dqn
    test_agent()
  File "dqn.py", line 244, in test_agent
    o, d, ep_ret, ep_len = test_env.reset(), False, 0, 0
  File "/Users/yeh/sandbox/rl/reinforcement-learning/DQN/atari_wrappers.py", line 230, in reset
    ob = self.env.reset()
  File "/Users/yeh/.local/share/virtualenvs/DQN-50XYwH7O/lib/python3.7/site-packages/gym/core.py", line 272, in reset
    return self.env.reset(**kwargs)
  File "/Users/yeh/.local/share/virtualenvs/DQN-50XYwH7O/lib/python3.7/site-packages/gym/core.py", line 259, in reset
    observation = self.env.reset(**kwargs)
  File "/Users/yeh/sandbox/rl/reinforcement-learning/DQN/atari_wrappers.py", line 72, in reset
    obs, _, done, _ = self.env.step(1)
  File "/Users/yeh/sandbox/rl/reinforcement-learning/DQN/atari_wrappers.py", line 94, in step
    obs, reward, done, info = self.env.step(action)
  File "/Users/yeh/.local/share/virtualenvs/DQN-50XYwH7O/lib/python3.7/site-packages/gym/wrappers/monitor.py", line 30, in step
    self._before_step(action)
  File "/Users/yeh/.local/share/virtualenvs/DQN-50XYwH7O/lib/python3.7/site-packages/gym/wrappers/monitor.py", line 160, in _before_step
    self.stats_recorder.before_step(action)
  File "/Users/yeh/.local/share/virtualenvs/DQN-50XYwH7O/lib/python3.7/site-packages/gym/wrappers/monitoring/stats_recorder.py", line 46, in before_step
    raise error.ResetNeeded("Trying to step environment which is currently done. While the monitor is active for {}, you cannot step beyond the end of an episode. Call 'env.reset()' to start the next episode.".format(self.env_id))
gym.error.ResetNeeded: Trying to step environment which is currently done. While the monitor is active for BreakoutNoFrameskip-v4, you cannot step beyond the end of an episode. Call 'env.reset()' to start the next episode.
```