### PR TITLE
Increase learning rate for VPG on ambiguous bandit

### DIFF
--- a/HCA/run_ambiguous_bandit.py
+++ b/HCA/run_ambiguous_bandit.py
@@ -10,8 +10,10 @@ config = dict(
     ac_kwargs={'hidden_sizes': []},
     gamma=0.99,
     seed=0,
+    pi_lr=0.2,
+    vf_lr=0.2,
     max_ep_len=1,
-    steps_per_epoch=128,
+    steps_per_epoch=2,
     epochs=100,
     n_test_episodes=100
 )


### PR DESCRIPTION
vf_lr: 1e-3 -> 0.3, pi_lr: 3e-4 -> 0.2.  Reduce steps per epoch 128->2. VPG is stable for these much larger learning rates, approaches optimal value in 200 episodes, whereas performance is close to random for the old small learning rates