### PR TITLE
Returns hca

### DIFF
--- a/HCA/run_ambiguous_bandit.py
+++ b/HCA/run_ambiguous_bandit.py
@@ -1,4 +1,5 @@
 import time
+import numpy as np
 import wandb
 
 #from spinup_vpg import vpg
@@ -21,12 +22,26 @@ from utils import plot_test_returns
 # )
 
 # tabular_vpg config
+# config = dict(
+#     env_kwargs={'OHE_obs': False,
+#                 'means': {'HI': 2, 'LO': 1},
+#                 'stds': {'HI': 1.5, 'LO': 1.5},
+#                 'epsilon': 0.1},
+#     ac_kwargs={'pi_lr': 0.2, 'vf_lr': 0.2},
+#     n_episodes=100,
+#     n_test_episodes=100,
+#     gamma=0.99,
+#     lam=0.95,
+# )
+
+# return HCA config
 config = dict(
     env_kwargs={'OHE_obs': False,
                 'means': {'HI': 2, 'LO': 1},
                 'stds': {'HI': 1.5, 'LO': 1.5},
                 'epsilon': 0.1},
-    ac_kwargs={'pi_lr': 0.2, 'vf_lr': 0.2},
+    ac_kwargs={'pi_lr': 0.3, 'vf_lr': 0.3, 'h_lr': 0.3,
+               'return_bins': np.arange(-.975,4.5,0.55)},
     n_episodes=100,
     n_test_episodes=100,
     gamma=0.99,
@@ -34,10 +49,10 @@ config = dict(
 )
 
 if __name__ == '__main__':
-    wandb.init(project="hca", config=config, tags=['ambiguous_bandit', 'tabular_vpg'])
+    wandb.init(project="hca", config=config, tags=['ambiguous_bandit', 'returns_hca'])
     logger_out_dir = wandb.run.dir
     logger_kwargs={'exp_name': 'hca', 'output_dir': logger_out_dir}
-    vpg(env_fn=AmbiguousBanditEnv, **config, actor_critic=tabular_actor_critic.TabularVPGActorCritic,
+    vpg(env_fn=AmbiguousBanditEnv, **config, actor_critic=tabular_actor_critic.TabularReturnHCA,
         logger_kwargs=logger_kwargs)
 
     plot_test_returns(logger_out_dir, 'progress.txt')

--- a/HCA/run_shortcut_env.py
+++ b/HCA/run_shortcut_env.py
@@ -4,6 +4,7 @@ import wandb
 #from spinup_vpg import vpg
 from tabular_vpg import vpg
 import shortcut_env
+import tabular_actor_critic
 from utils import plot_test_returns
 
 # spinup_vpg config
@@ -27,10 +28,12 @@ config = dict(
     gamma=0.99,
     lam=0.95,
 )
+
 if __name__ == '__main__':
     wandb.init(project="hca", config=config, tags=['shortcut_env', 'tabular_vpg'])
     logger_out_dir = wandb.run.dir
     logger_kwargs={'exp_name': 'hca', 'output_dir': logger_out_dir}
-    vpg(shortcut_env.ShortcutEnv, **config, logger_kwargs=logger_kwargs)
+    vpg(shortcut_env.ShortcutEnv, **config, actor_critic=tabular_actor_critic.TabularVPGActorCritic,
+        logger_kwargs=logger_kwargs)
 
     plot_test_returns(logger_out_dir, 'progress.txt')

--- a/HCA/tabular_actor_critic.py
+++ b/HCA/tabular_actor_critic.py
@@ -53,3 +53,49 @@ class TabularVPGActorCritic(BaseTabularActorCritic):
         dlogits_pi, dV = self.compute_errors(traj)
         self.logits_pi += self.pi_lr * dlogits_pi
         self.V += self.vf_lr * dV
+
+
+class TabularReturnHCA(BaseTabularActorCritic):
+    """
+    Discrete observation and action space
+    """
+    def __init__(self, obs_dim, act_dim, return_bins,
+                 pi_lr=0.1, vf_lr=0.1, h_lr=0.1):
+        """return_bins is a 1-dimensional np.array
+        """
+        self._return_bins = return_bins
+        num_bins = len(return_bins)
+        self.logits_h = np.zeros((act_dim, obs_dim, num_bins))
+        self.h_lr = h_lr
+        super().__init__(obs_dim, act_dim, pi_lr, vf_lr)
+
+    @property
+    def h(self):
+        Z = np.exp(self.logits_h).sum(axis=0, keepdims=True)
+        h = np.exp(self.logits_h) / Z
+        return h
+
+    def compute_errors(self, traj):
+        T = len(traj.states)
+        dlogits_pi = np.zeros_like(self.pi)
+        dV = np.zeros_like(self.V)
+        dlogits_h = np.zeros_like(self.h)
+
+        for i in range(T):
+            x_s, a_s, G = traj.states[i], traj.actions[i], traj.returns[i]
+            G_bin_ind = (np.abs(self._return_bins - G)).argmin()
+            hca_factor = (1. - self.pi[x_s, :] / self.h[:, x_s, G_bin_ind])
+            G_hca = G * hca_factor
+
+            dlogits_pi[x_s, a_s] += G_hca[a_s]
+            dlogits_pi[x_s] -= self.pi[x_s] * G_hca[a_s]
+            dV[x_s] += (G - self.V[x_s])
+            dlogits_h[a_s, x_s, G_bin_ind] += 1
+            dlogits_h[:, x_s, G_bin_ind] -= self.h[:, x_s, G_bin_ind]
+        return dlogits_pi, dV, dlogits_h
+
+    def update(self, traj):
+        dlogits_pi, dV, dlogits_h = self.compute_errors(traj)
+        self.logits_pi += self.pi_lr * dlogits_pi
+        self.V += self.vf_lr * dV
+        self.logits_h += self.h_lr * dlogits_h

--- a/HCA/tabular_actor_critic.py
+++ b/HCA/tabular_actor_critic.py
@@ -8,15 +8,15 @@ class BaseTabularActorCritic(ABC):
     """
     def __init__(self, obs_dim, act_dim, pi_lr=0.1, vf_lr=0.1):
         self._actions = np.array(range(act_dim))
-        self.logits = np.zeros((obs_dim, act_dim))
+        self.logits_pi = np.zeros((obs_dim, act_dim))
         self.V = np.zeros(obs_dim)
         self.pi_lr = pi_lr
         self.vf_lr = vf_lr
 
     @property
     def pi(self):
-        Z = np.exp(self.logits).sum(axis=1, keepdims=True)
-        pi = np.exp(self.logits) / Z
+        Z = np.exp(self.logits_pi).sum(axis=1, keepdims=True)
+        pi = np.exp(self.logits_pi) / Z
         return pi
 
     def step(self, obs):
@@ -39,17 +39,17 @@ class TabularVPGActorCritic(BaseTabularActorCritic):
 
     def compute_errors(self, traj):
         T = len(traj.states)
-        dlogits = np.zeros_like(self.pi)
+        dlogits_pi = np.zeros_like(self.pi)
         dV = np.zeros_like(self.V)
 
         for i in range(T):
             x_s, a_s, ret, adv = traj.states[i], traj.actions[i], traj.returns[i], traj.advantage[i]
-            dlogits[x_s, a_s] += adv
-            dlogits[x_s] -= self.pi[x_s] * adv
+            dlogits_pi[x_s, a_s] += adv
+            dlogits_pi[x_s] -= self.pi[x_s] * adv
             dV[x_s] += (ret - self.V[x_s])
-        return dlogits, dV
+        return dlogits_pi, dV
 
     def update(self, traj):
-        dlogits, dV = self.compute_errors(traj)
-        self.logits += self.pi_lr * dlogits
+        dlogits_pi, dV = self.compute_errors(traj)
+        self.logits_pi += self.pi_lr * dlogits_pi
         self.V += self.vf_lr * dV

--- a/HCA/tabular_vpg.py
+++ b/HCA/tabular_vpg.py
@@ -145,6 +145,8 @@ def vpg(env_fn, actor_critic=tabular_actor_critic.TabularVPGActorCritic,
     print('pi', ac.pi, flush=True)
     print('logits_pi', ac.logits_pi, flush=True)
     print('value', ac.V, flush=True)
+    if isinstance(ac, tabular_actor_critic.TabularReturnHCA):
+        print('h', ac.h, flush=True)
 
 
 if __name__ == '__main__':

--- a/HCA/tabular_vpg.py
+++ b/HCA/tabular_vpg.py
@@ -143,7 +143,7 @@ def vpg(env_fn, actor_critic=tabular_actor_critic.TabularVPGActorCritic,
             o, ep_ret, ep_len = env.reset(), 0, 0
 
     print('pi', ac.pi, flush=True)
-    print('logits', ac.logits, flush=True)
+    print('logits_pi', ac.logits_pi, flush=True)
     print('value', ac.V, flush=True)
 
 


### PR DESCRIPTION
The crux of the new logic is in the `compute_errors` method of `class TabularReturnHCA` in tabular_actor_critic.py.  The code was copied from https://github.com/hca-neurips2019/hca/blob/master/hca_classes.py.

Returns HCA run on ambiguous bandit here using a `returns_bin` of `np.arange(-.975,4.5,0.55)` which results in 10 bins: https://app.wandb.ai/frangipane/hca/reports/Ambiguous-Bandit-VPG--Vmlldzo2OTQ2NA

paper results fig. 5: https://arxiv.org/pdf/1912.02503.pdf