### PR TITLE
Add bootstrap in tabular_vpg

### DIFF
--- a/HCA/run_delayed_effect_env.py
+++ b/HCA/run_delayed_effect_env.py
@@ -9,27 +9,27 @@ from utils import plot_test_returns
 
 
 # # tabular_vpg config
-config = dict(
-    env_kwargs={'OHE_obs': False,
-                'n': 3,
-                'final_reward': 1.0,
-                'sigma': 2.0},
-    ac_kwargs={'pi_lr': 0.2, 'vf_lr': 0.2},
-    n_episodes=500,
-    n_test_episodes=100,
-    gamma=1.0,
-    lam=1.0,
-    actor_critic=tabular_actor_critic.TabularVPGActorCritic,
-    algo='vpg',
-    bootstrap='MC'
-)
+# config = dict(
+#     env_kwargs={'OHE_obs': False,
+#                 'n': 4,
+#                 'final_reward': 1.0,
+#                 'sigma': 0.0},
+#     ac_kwargs={'pi_lr': 0.2, 'vf_lr': 0.2},
+#     n_episodes=500,
+#     n_test_episodes=100,
+#     gamma=1.0,
+#     lam=1.0,
+#     actor_critic=tabular_actor_critic.TabularVPGActorCritic,
+#     algo='vpg',
+#     bootstrap_n=3
+# )
 
 # # return HCA config
 # config = dict(
 #     env_kwargs={'OHE_obs': False,
-#                 'n': 3,
+#                 'n': 4,
 #                 'final_reward': 1.0,
-#                 'sigma': 2.0},
+#                 'sigma': 0.0},
 #     ac_kwargs={'pi_lr': 0.2, 'vf_lr': 0.2, 'h_lr': 0.2, 'return_bins': np.array([-1,0,1])},
 #     n_episodes=500,
 #     n_test_episodes=100,
@@ -37,29 +37,29 @@ config = dict(
 #     lam=1.0,
 #     actor_critic=tabular_actor_critic.TabularReturnHCA,
 #     algo='returnHCA',
-#     bootstrap='MC'
+#     bootstrap_n=3
 # )
 
 # state HCA config
- # config = dict(
-#     env_kwargs={'OHE_obs': False,
-#                 'n': 3,
-#                 'final_reward': 1.0,
-#                 'sigma': 2.0},
-#     ac_kwargs={'pi_lr': 0.2, 'vf_lr': 0.2, 'h_lr': 0.4},
-#     n_episodes=500,
-#     n_test_episodes=100,
-#     gamma=1.0,
-#     lam=1.0,
-#     actor_critic=tabular_actor_critic.TabularStateHCA,
-#     algo='stateHCA',
-#     bootstrap='MC'
-# )
+config = dict(
+    env_kwargs={'OHE_obs': False,
+                'n': 4,
+                'final_reward': 1.0,
+                'sigma': 0.0},
+    ac_kwargs={'pi_lr': 0.2, 'vf_lr': 0.2, 'h_lr': 0.4},
+    n_episodes=500,
+    n_test_episodes=100,
+    gamma=1.0,
+    lam=1.0,
+    actor_critic=tabular_actor_critic.TabularStateHCA,
+    algo='stateHCA',
+    bootstrap_n=3
+)
 
 
 if __name__ == '__main__':
     algo = config.pop('algo')
-    bootstrap = config.pop('bootstrap')
+    bootstrap = str(config['bootstrap_n'])
 
     wandb.init(
         project="hca",

--- a/HCA/test_trajectory.py
+++ b/HCA/test_trajectory.py
@@ -1,0 +1,80 @@
+import pytest
+import numpy as np
+
+from tabular_vpg import Trajectory
+
+
+@pytest.fixture(scope='module')
+def steps():
+    obs = [0]*4
+    act = [0]*4
+    rew = [1, 0.5, 0, -0.5]
+    val = [0, 0.5, 1.0, 1.1]
+    last_obs = 0
+    last_val = 0
+    return (obs, act, rew, val, last_obs, last_val)
+
+
+@pytest.fixture(scope='module')
+def traj_bootstrap(steps):
+    """4 step episode
+    states and actions don't matter
+    """
+    obs, act, rew, val, last_obs, last_val = steps
+    tr = Trajectory(gamma=1.0, lam=1.0, bootstrap_n=2)
+    for o, a, r, v in zip(obs, act, rew, val):
+        tr.store(o, a, r, v)
+    tr.finish_path(last_obs=last_obs, last_val=last_val)
+    return tr
+
+
+@pytest.fixture(scope='module')
+def traj_MC(steps):
+    """4 step episode
+    states and actions don't matter
+    """
+    obs, act, rew, val, last_obs, last_val = steps
+    tr = Trajectory(gamma=1.0, lam=1.0, bootstrap_n=None)
+    for o, a, r, v in zip(obs, act, rew, val):
+        tr.store(o, a, r, v)
+    tr.finish_path(last_obs=last_obs, last_val=last_val)
+    return tr
+
+
+def test_traj_bootstrap(traj_bootstrap):
+    rews = traj_bootstrap.rewards
+    vals = traj_bootstrap.values
+    vals.append(traj_bootstrap.last_val)
+
+    n = traj_bootstrap.bootstrap_n
+    g = traj_bootstrap.gamma
+
+    # assumes trajectory has length 4
+    assert len(rews) == 4
+    expected_returns = [(g ** np.arange(n+1) * np.array(rews[0:n] + [vals[n]])).sum()] \
+        + [(g ** np.arange(n+1) * np.array(rews[1:n+1] + [vals[n+1]])).sum()] \
+        + [(g ** np.arange(n+1) * np.array(rews[2:n+2] + [vals[n+2]])).sum()] \
+        + [(g ** np.arange(n) * np.append(np.array(rews[n+1]), vals[n+2])).sum()]  # truncated bootstrap
+    assert expected_returns == traj_bootstrap.returns
+
+    expected_adv = (np.array(expected_returns) - np.array(vals[:-1])).tolist()
+    assert expected_adv == traj_bootstrap.advantage
+
+
+def test_traj_MC(traj_MC):
+    rews = traj_MC.rewards
+    n = len(rews)
+    g = traj_MC.gamma
+
+    # assumes trajectory has length 4 and lamda=1 and last_val was 0 (episode ended)
+    assert len(rews) == 4
+    assert traj_MC.lam == 1.0
+    assert traj_MC.last_val == 0.0
+    expected_returns = [(g ** np.arange(n) * np.array(rews[0:])).sum()] \
+                       + [(g ** np.arange(n-1) * np.array(rews[1:])).sum()] \
+                       + [(g ** np.arange(n-2) * np.array(rews[2:])).sum()] \
+                       + [(g ** np.arange(n-3) * np.array(rews[3:])).sum()]
+    assert expected_returns == traj_MC.returns
+
+    expected_adv = (np.array(expected_returns) - np.array(traj_MC.values)).tolist()
+    assert expected_adv == traj_MC.advantage


### PR DESCRIPTION
Add n-step bootstrapping option to tabular_vpg.  Note, monte-carlo returns are handled by setting  `bootstrap_n` to None and `lam=1` for GAE-lambda.