### PR TITLE
Fix shortcut env test expected reward

### DIFF
--- a/HCA/tests/test_shortcut_env.py
+++ b/HCA/tests/test_shortcut_env.py
@@ -30,7 +30,7 @@ def test_always_shortcut():
         o = env.reset()
         if o != final_state:
             o2, r, _, _ = env.step(action)
-            assert r == 1.0
+            assert r == 0.0
             assert o2 == n-1
 
 


### PR DESCRIPTION
Did not account for step penalty, i.e. expected is 1+-1=0